### PR TITLE
New merge tags when not present on entry object

### DIFF
--- a/includes/fields/class-gravityview-field.php
+++ b/includes/fields/class-gravityview-field.php
@@ -189,6 +189,8 @@ abstract class GravityView_Field {
 			// Replace the value from the entry, if exists
 			if( isset( $entry[ $tag ] ) ) {
 				$text = str_replace( $full_tag, $entry[ $tag ], $text );
+			} else {
+				$text = '';
 			}
 		}
 


### PR DESCRIPTION
I tested adding the {transaction_id} merge tag and because the
transaction_id is not part of the entry object, it simply shows
“{transaction_id}”. Is this expected?