### PR TITLE
Fix Quiz and Poll fields

### DIFF
--- a/includes/class-api.php
+++ b/includes/class-api.php
@@ -214,7 +214,7 @@ class GravityView_API {
 	 *
 	 * @access public
 	 * @param array $entry
-	 * @param integer $field
+	 * @param array $field
 	 * @return null|string
 	 */
 	public static function field_value( $entry, $field_settings, $format = 'html' ) {
@@ -312,6 +312,7 @@ class GravityView_API {
 
 		}
 
+		// Get the field settings again so that the field template can override the settings
 		$field_settings = $gravityview_view->getCurrentField('field_settings');
 
 		/**
@@ -774,7 +775,7 @@ function gv_value( $entry, $field ) {
 
 	$value = GravityView_API::field_value( $entry, $field );
 
-	if( $value === '') {
+	if( $value === '' ) {
 		/**
 		 * @filter `gravityview_empty_value` What to display when a field is empty
 		 * @param string $value (empty string)

--- a/includes/class-api.php
+++ b/includes/class-api.php
@@ -225,24 +225,6 @@ class GravityView_API {
 
 		$gravityview_view = GravityView_View::getInstance();
 
-		if( class_exists( 'GFCache' ) ) {
-			/**
-			 * Gravity Forms' GFCache function was thrashing the database, causing double the amount of time for the field_value() method to run.
-			 *
-			 * The reason is that the cache was checking against a field value stored in a transient every time `GFFormsModel::get_lead_field_value()` is called.
-			 *
-			 * What we're doing here is telling the GFCache that it's already checked the transient and the value is false, forcing it to just use the non-cached data, which is actually faster.
-			 *
-			 * @hack
-			 * @since  1.3
-			 * @param  string $cache_key Field Value transient key used by Gravity Forms
-			 * @param mixed false Setting the value of the cache to false so that it's not used by Gravity Forms' GFFormsModel::get_lead_field_value() method
-			 * @param boolean false Tell Gravity Forms not to store this as a transient
-			 * @param  int 0 Time to store the value. 0 is maximum amount of time possible.
-			 */
-			GFCache::set( "GFFormsModel::get_lead_field_value_" . $entry["id"] . "_" . $field_settings["id"], false, false, 0 );
-		}
-
 		$field_id = $field_settings['id'];
 
 		$form = $gravityview_view->getForm();

--- a/includes/class-common.php
+++ b/includes/class-common.php
@@ -928,7 +928,7 @@ class GVCommon {
 	 * @access public
 	 * @param array $form
 	 * @param string|int $field_id
-	 * @return array|null Array: Gravity Forms field array; NULL: Gravity Forms GFFormsModel does not exist
+	 * @return GF_Field|null Gravity Forms field object, or NULL: Gravity Forms GFFormsModel does not exist or field at $field_id doesn't exist.
 	 */
 	public static function get_field( $form, $field_id ) {
 		if ( class_exists( 'GFFormsModel' ) ){

--- a/includes/connector-functions.php
+++ b/includes/connector-functions.php
@@ -128,14 +128,14 @@ function gravityview_get_field_label( $form, $field_id ) {
 /**
  * Returns the field details array of a specific form given the field id
  *
- * Alias of Alias of GFFormsModel::get_field
+ * Alias of GFFormsModel::get_field
  *
  * @uses GVCommon::get_field
  * @see GFFormsModel::get_field
  * @access public
  * @param array $form
  * @param string|int $field_id
- * @return array
+ * @return GF_Field|null Returns NULL if field with ID $field_id doesn't exist.
  */
 function gravityview_get_field( $form, $field_id ) {
 	return GVCommon::get_field( $form, $field_id );

--- a/includes/fields/class-gravityview-field-date.php
+++ b/includes/fields/class-gravityview-field-date.php
@@ -32,6 +32,51 @@ class GravityView_Field_Date extends GravityView_Field {
 		return $field_options;
 	}
 
+	/**
+	 * Get the default date format for a field based on the field ID and the time format setting
+	 *
+	 * @since 1.16.4
+
+	 * @param string $date_format The Gravity Forms date format for the field. Default: "mdy"
+	 * @param int $field_id The ID of the field. Used to figure out full date/day/month/year
+	 *
+	 * @return string PHP date format for the date
+	 */
+	static public function date_display( $value = '', $date_format = 'mdy', $field_id = 0 ) {
+
+		// Let Gravity Forms figure out, based on the date format, what day/month/year values are.
+		$parsed_date = GFCommon::parse_date( $value, $date_format );
+
+		// Are we displaying an input or the whole field?
+		$field_input_id = gravityview_get_input_id_from_id( $field_id );
+
+		$date_field_output = '';
+		switch( $field_input_id ) {
+			case 1:
+				$date_field_output = rgar( $parsed_date, 'day' );
+				break;
+			case 2:
+				$date_field_output = rgar( $parsed_date, 'month' );
+				break;
+			case 3:
+				$date_field_output = rgar( $parsed_date, 'year' );
+				break;
+		}
+
+		/**
+		 * @filter `gravityview_date_format` Whether to override the Gravity Forms date format with a PHP date format
+		 * @see https://codex.wordpress.org/Formatting_Date_and_Time
+		 * @param null|string Date Format (default: $field->dateFormat)
+		 */
+		$full_date_format = apply_filters( 'gravityview_date_format', $date_format );
+
+		$full_date = GFCommon::date_display( $value, $full_date_format );
+
+		// If the field output is empty, use the full date.
+		// Note: The output might be empty because $parsed_date didn't parse correctly.
+		return ( '' === $date_field_output ) ? $full_date : $date_field_output;
+	}
+
 }
 
 new GravityView_Field_Date;

--- a/includes/fields/class-gravityview-field-list.php
+++ b/includes/fields/class-gravityview-field-list.php
@@ -116,14 +116,12 @@ class GravityView_Field_List extends GravityView_Field {
 			return $label;
 		}
 
-		$field_id_array = explode( '.', $field['id'] );
+		$column_id = gravityview_get_input_id_from_id( $field['id'] );
 
 		// Parent field, not column field
-		if( ! isset( $field_id_array[1] ) ) {
+		if( empty( $column_id ) ) {
 			return $label;
 		}
-
-		$column_id = intval( $field_id_array[1] );
 
 		return self::get_column_label( $field_object, $column_id, $label );
 	}

--- a/includes/fields/class-gravityview-field-quiz.php
+++ b/includes/fields/class-gravityview-field-quiz.php
@@ -1,0 +1,40 @@
+<?php
+/**
+ * @file class-gravityview-field-gquiz_score.php
+ * @package GravityView
+ * @subpackage includes\fields
+ */
+
+class GravityView_Field_Quiz extends GravityView_Field {
+
+	var $name = 'quiz';
+
+	var $group = 'advanced';
+
+	public function __construct() {
+		$this->label = esc_html__( 'Quiz', 'gravityview' );
+		parent::__construct();
+	}
+
+	function field_options( $field_options, $template_id, $field_id, $context, $input_type ) {
+
+		if( 'edit' === $context ) {
+			return $field_options;
+		}
+
+		$new_fields = array(
+			'quiz_show_explanation' => array(
+				'type' => 'checkbox',
+				'label' => __( 'Show Answer Explanation?', 'gravityview' ),
+				'desc' => __('If the field has an answer explanation, show it?', 'gravityview'),
+				'value' => false,
+				'merge_tags' => false,
+			),
+		);
+
+		return $new_fields + $field_options;
+	}
+
+}
+
+new GravityView_Field_Quiz;

--- a/includes/fields/class-gravityview-field-time.php
+++ b/includes/fields/class-gravityview-field-time.php
@@ -282,9 +282,7 @@ class GravityView_Field_Time extends GravityView_Field {
 	 */
 	static public function date_format( $time_format = '12', $field_id = 0 ) {
 
-		$field_id_array = explode( '.', $field_id );
-
-		$field_input_id = isset( $field_id_array[1] ) ? intval( $field_id_array[1] ) : 0;
+		$field_input_id = gravityview_get_input_id_from_id( $field_id );
 
 		$default = 'h:i A';
 

--- a/includes/helper-functions.php
+++ b/includes/helper-functions.php
@@ -428,6 +428,30 @@ function gravityview_is_valid_datetime( $datetime, $expected_format = 'Y-m-d' ) 
 }
 
 /**
+ * Very commonly needed: get the # of the input based on a full field ID.
+ *
+ * Example: 12.3 => field #12, input #3. Returns: 3
+ * Example: 7 => field #7, no input. Returns: 0
+ *
+ * @since 1.16.4
+ *
+ * @param string $field_id Full ID of field, with or without input ID, like "12.3" or "7".
+ *
+ * @return int If field ID has an input, returns that input number. Otherwise, returns 0.
+ */
+function gravityview_get_input_id_from_id( $field_id = '' ) {
+
+	if ( ! is_numeric( $field_id ) ) {
+		do_action( 'gravityview_log_error', __FUNCTION__ . ': $field_id not numeric', $field_id );
+		return false;
+	}
+
+	$exploded = explode( '.', "{$field_id}" );
+
+	return isset( $exploded[1] ) ? intval( $exploded[1] ) : 0;
+}
+
+/**
  * Get categories formatted in a way used by GravityView and Gravity Forms input choices
  *
  * @since 1.15.3

--- a/includes/widgets/poll/templates/widget-poll.php
+++ b/includes/widgets/poll/templates/widget-poll.php
@@ -13,4 +13,4 @@ $gravityview_view = GravityView_View::getInstance();
  */
 $merge_tag = $gravityview_view->poll_merge_tag;
 
-echo GFCommon::replace_variables( $merge_tag, $gravityview_view->getForm(), array() );
+echo GFCommon::replace_variables( $merge_tag, $gravityview_view->getForm(), array( 'id' => 0 ) );

--- a/readme.txt
+++ b/readme.txt
@@ -24,10 +24,13 @@ Beautifully display your Gravity Forms entries. Learn more on [gravityview.co](h
 
 * Fixed: `[gravityview]` shortcodes sometimes not rendering inside page builder shortcodes
 * Fixed: Don't show GravityView Approve Entry column in Gravity Forms Entries table if there are no entries
+* Fixed: Individual date inputs (Day/Month/Year) always would show full date.
+* Tweak: Updated `templates/fields/date.php` template to use new `GravityView_Field_Date::date_display()` method.
 * Added `gv-widgets-no-results` and `gv-container-no-results` classes to the widget and View container `<div>`s. This will make it easier to hide empty View content and/or Widgets.
 * Added: New action hooks when entry is deleted (`gravityview/delete-entry/deleted`) or trashed (`gravityview/delete-entry/trashed`).
 * Added: Use the hook `gravityview/search/method` to change the default search method from `GET` to `POST` (hiding the search filters from the View url)
 * Added: `gravityview/extension/search/select_default` filter to modify default value for Drop Down and Multiselect Search Bar fields.
+* Added: `gravityview_get_input_id_from_id()` helper function to get the Input ID from a Field ID.
 
 = 1.16.3 on February 28 =
 

--- a/templates/fields/date.php
+++ b/templates/fields/date.php
@@ -17,7 +17,8 @@ extract( $gravityview_view->getCurrentField() );
 if( $value === '1970-01-01' ) {
 
 	/**
-	 * Return false to show value. Use `__return_false` callback.
+	 * @filter `gravityview/fields/date/hide_epoch` Whether to hide `1970-01-01` dates; that is normally an erroneous date. Return false to show value. Use `__return_false` callback.
+	 * @param bool $hide_epoch True: hide values that are 1970-01-01. False: show the value.
 	 */
 	$hide_epoch = apply_filters( 'gravityview/fields/date/hide_epoch', true );
 
@@ -35,13 +36,7 @@ if( !empty( $field_settings ) && !empty( $field_settings['date_display'] ) && !e
 
 } else {
 
-	/**
-	 * @filter `gravityview_date_format` Whether to override the Gravity Forms date format with a PHP date format
-	 * @see https://codex.wordpress.org/Formatting_Date_and_Time
-	 * @param null|string Date Format (default: $field->dateFormat)
-	 */
-	$format = apply_filters( 'gravityview_date_format', rgar($field, "dateFormat") );
-	$output = GFCommon::date_display( $value, $format );
+	$output = GravityView_Field_Date::date_display( $value, rgar($field, "dateFormat"), $field_id );
 
 }
 

--- a/templates/fields/gquiz_grade.php
+++ b/templates/fields/gquiz_grade.php
@@ -11,7 +11,7 @@ $gravityview_view = GravityView_View::getInstance();
 $field = $gravityview_view->getCurrentField();
 
 // If there's no grade, don't continue
-if( empty( $field['value'] ) ) {
+if( gv_empty( $field['value'], false, false ) ) {
 	return;
 }
 

--- a/templates/fields/gquiz_grade.php
+++ b/templates/fields/gquiz_grade.php
@@ -20,7 +20,7 @@ $grading_type_enabled = !empty( $field['form']['gravityformsquiz']['grading'] ) 
 
 if( 'letter' === $grading_type_enabled ) {
 	echo $field['value'];
-} elseif( GVCommon::has_cap( 'manage_options' ) ) {
+} elseif( GVCommon::has_cap( 'gravityforms_edit_forms' ) ) {
 	$grade_type = __( 'Letter', 'gravityview' );
 	printf( esc_html_x( '%s grading is disabled for this form. %sChange the setting%s', '%s is the current Quiz field type ("Letter" or "Pass/Fail")', 'gravityview' ), $grade_type, '<a href="'. admin_url('admin.php?page=gf_edit_forms&amp;view=settings&amp;subview=gravityformsquiz&amp;id='.$gravityview_view->getFormId() ) . '">', '</a>' );
 }

--- a/templates/fields/gquiz_is_pass.php
+++ b/templates/fields/gquiz_is_pass.php
@@ -11,7 +11,7 @@ $gravityview_view = GravityView_View::getInstance();
 $field = $gravityview_view->getCurrentField();
 
 // If there's no grade, don't continue
-if( empty( $field['value'] ) ) {
+if( gv_empty( $field['value'], false, false ) ) {
 	return;
 }
 

--- a/templates/fields/gquiz_is_pass.php
+++ b/templates/fields/gquiz_is_pass.php
@@ -23,7 +23,7 @@ if( 'passfail' === $grading_type_enabled ) {
 	// By default, the field value is "1" for Pass and "0" for Fail. We want the text.
 	echo GFCommon::replace_variables( '{quiz_passfail}', $gravityview_view->getForm(), $gravityview_view->getCurrentEntry() );
 
-} elseif( GVCommon::has_cap( 'manage_options' ) ) {
+} elseif( GVCommon::has_cap( 'gravityforms_edit_forms' ) ) {
 	$grade_type = __( 'Pass/Fail', 'gravityview' );
 	printf( esc_html_x( '%s grading is disabled for this form. %sChange the setting%s', '%s is the current Quiz field type ("Letter" or "Pass/Fail")', 'gravityview' ), $grade_type, '<a href="'. admin_url('admin.php?page=gf_edit_forms&amp;view=settings&amp;subview=gravityformsquiz&amp;id='.$gravityview_view->getFormId() ) . '">', '</a>' );
 }

--- a/templates/fields/gquiz_percent.php
+++ b/templates/fields/gquiz_percent.php
@@ -9,7 +9,7 @@
 $field = GravityView_View::getInstance()->getCurrentField();
 
 // If there's no grade, don't continue
-if( empty( $field['value'] ) ) {
+if( gv_empty( $field['value'], false, false ) ) {
 	return;
 }
 

--- a/templates/fields/gquiz_percent.php
+++ b/templates/fields/gquiz_percent.php
@@ -14,13 +14,9 @@ if( gv_empty( $field['value'], false, false ) ) {
 }
 
 /**
- * Modify the format of the display of the field.
- *
- * Notice the double `%%`, this prints a literal '%' character
- *
+ * @filter `gravityview/field/quiz_percent/format` Modify the format of the display of Quiz Score (Percent) field.
  * @see http://php.net/manual/en/function.sprintf.php For formatting guide
- *
- * @param string $format Format passed to printf() function. Default `%d%%`, which prints as "{number}%"
+ * @param string $format Format passed to printf() function. Default `%d%%`, which prints as "{number}%". Notice the double `%%`, this prints a literal '%' character.
  */
 $format = apply_filters('gravityview/field/quiz_percent/format', '%d%%');
 

--- a/templates/fields/gquiz_score.php
+++ b/templates/fields/gquiz_score.php
@@ -11,7 +11,7 @@ $gravityview_view = GravityView_View::getInstance();
 $field = $gravityview_view->getCurrentField();
 
 // If there's no grade, don't continue
-if( empty( $field['value'] ) ) {
+if( gv_empty( $field['value'], false, false ) ) {
 	return;
 }
 

--- a/templates/fields/list.php
+++ b/templates/fields/list.php
@@ -15,9 +15,9 @@ $gravityview_view = GravityView_View::getInstance();
 
 extract( $gravityview_view->getCurrentField() );
 
-$field_id_array = explode( '.', $field_id );
+$column_id = gravityview_get_input_id_from_id( $field_id );
 
-if( $field->enableColumns && isset( $field_id_array[1] ) ) {
+if( $field->enableColumns && ! empty( $column_id ) ) {
 
 	/**
 	 * @filter `gravityview/fields/list/column-format` Format of single list column output of a List field with Multiple Columns enabled
@@ -26,7 +26,7 @@ if( $field->enableColumns && isset( $field_id_array[1] ) ) {
 	 */
 	$format = apply_filters( 'gravityview/fields/list/column-format', 'html' );
 
-	echo GravityView_Field_List::column_value( $field, $value, intval( $field_id_array[1] ), $format );
+	echo GravityView_Field_List::column_value( $field, $value, $column_id, $format );
 
 } else {
 	echo $display_value;

--- a/templates/fields/quiz.php
+++ b/templates/fields/quiz.php
@@ -1,0 +1,25 @@
+<?php
+/**
+ * Display Gravity Forms Quiz output
+ *
+ * @package GravityView
+ * @subpackage GravityView/templates/fields
+ */
+
+$gravityview_view = GravityView_View::getInstance();
+
+$field = $gravityview_view->getCurrentField();
+
+// If there's no grade, don't continue
+if( gv_empty( $field['value'] ) ) {
+	return;
+}
+
+// Get the setting for show/hide explanation
+$show_answer = rgars( $field, 'field_settings/quiz_show_explanation' );
+
+// Update the quiz field so GF generates the output properly
+$field['field']->gquizShowAnswerExplanation = ! empty( $show_answer );
+
+// Generate the output
+echo GFQuiz::get_instance()->display_quiz_on_entry_detail( $field['value'], $field['field'], $field['entry'], $field['form'] );

--- a/templates/fields/quiz.php
+++ b/templates/fields/quiz.php
@@ -15,6 +15,11 @@ if( gv_empty( $field['value'] ) ) {
 	return;
 }
 
+if( ! class_exists('GFQuiz') ) {
+	do_action('gravityview_log_error', __FILE__ . ': GFQuiz class does not exist.' );
+	return;
+}
+
 // Get the setting for show/hide explanation
 $show_answer = rgars( $field, 'field_settings/quiz_show_explanation' );
 

--- a/tests/factory.php
+++ b/tests/factory.php
@@ -370,7 +370,14 @@ class GF_UnitTest_Factory_For_Entry extends WP_UnitTest_Factory_For_Thing {
 	}
 
 	function create_object( $args ) {
+
 		$args = wp_parse_args( $args, $this->default_generation_definitions );
+
+		if( !isset( $args['form_id'] ) ) {
+			$form = $this->factory->form->create();
+			$args['form_id'] = $form['id'];
+		}
+
 		return GFAPI::add_entry( $args );
 	}
 

--- a/tests/unit-tests/helper-functions_Test.php
+++ b/tests/unit-tests/helper-functions_Test.php
@@ -158,6 +158,31 @@ class GravityView_Helper_Functions_Test extends GV_UnitTestCase {
 	}
 
 	/**
+	 * @since 1.16.4
+	 * @covers ::gravityview_get_input_id_from_id()
+	 */
+	public function test_gravityview_get_input_id_from_id() {
+		
+		$tests = array(
+			'1' => 0,
+			'1.0' => 0,
+			'1.10' => 10,
+			'12.2' => 2,
+			'12.02' => 2, // Shouldn't happen
+			'871.57' => 57,
+			'asdasdsd' => false, // non-numeric is false
+		);
+
+		foreach ( $tests as $field_id => $expected ) {
+			$formatted = gravityview_get_input_id_from_id( $field_id );
+			$this->assertEquals( $expected, $formatted );
+		}
+
+		$this->assertEquals( 0, gravityview_get_input_id_from_id( 38 ), 'integer value' );
+		$this->assertEquals( 12, gravityview_get_input_id_from_id( 38.12 ), 'float value' );
+	}
+
+	/**
 	 * @covers ::gravityview_sanitize_html_class()
 	 */
 	public function test_gravityview_sanitize_html_class() {

--- a/tests/unit-tests/helper-functions_Test.php
+++ b/tests/unit-tests/helper-functions_Test.php
@@ -200,7 +200,7 @@ class GravityView_Helper_Functions_Test extends GV_UnitTestCase {
 
 	/**
 	 * @covers ::gravityview_format_link()
-	 * @covers :: _gravityview_strip_subdomain()
+	 * @covers ::_gravityview_strip_subdomain()
 	 */
 	public function test_gravityview_format_link_DEFAULT() {
 


### PR DESCRIPTION
Quiz and Polls addons were breaking because they use
`gform_entry_field_value` filter, and the `$field` variable being
passed was an array, not `GF_Field`.