### PR TITLE
Add/decode shortcodes

### DIFF
--- a/includes/class-api.php
+++ b/includes/class-api.php
@@ -658,7 +658,15 @@ class GravityView_API {
 
 			$args = array();
 
-			$directory_link = trailingslashit( $directory_link ) . $query_arg_name . '/'. $entry_slug .'/';
+			/**
+			 * Make sure the $directory_link doesn't contain any query otherwise it will break when adding the entry slug.
+			 * @since 1.16.5
+			 */
+			$link_parts = explode( '?', $directory_link );
+
+			$query = !empty( $link_parts[1] ) ? '?'.$link_parts[1] : '';
+
+			$directory_link = trailingslashit( $link_parts[0] ) . $query_arg_name . '/'. $entry_slug .'/' . $query;
 
 		} else {
 

--- a/includes/class-common.php
+++ b/includes/class-common.php
@@ -1129,7 +1129,17 @@ class GVCommon {
 	 * @return array          Multi-array of fields with first level being the field zones. See code comment.
 	 */
 	public static function get_directory_fields( $post_id ) {
-		return get_post_meta( $post_id, '_gravityview_directory_fields', true );
+		$fields = get_post_meta( $post_id, '_gravityview_directory_fields', true );
+
+		/**
+		 * @filter `gravityview/configuration/fields` Filter the View fields' configuration array
+		 * @since 1.6.5
+		 * @param $fields array Multi-array of fields with first level being the field zones
+		 * @param $post_id int Post ID
+		 */
+		$fields = apply_filters( 'gravityview/configuration/fields', $fields, $post_id );
+
+		return $fields;
 	}
 
 

--- a/includes/class-common.php
+++ b/includes/class-common.php
@@ -1501,6 +1501,18 @@ class GVCommon {
         return '<div class="gv-notice '.gravityview_sanitize_html_class( $class ) .'">'. $notice .'</div>';
     }
 
+	/**
+	 * Inspired on \GFCommon::encode_shortcodes
+	 * @param $string
+	 * @return $string
+	 */
+	public static function decode_shortcodes( $string ) {
+		$replace = array( '[', ']' );
+		$find = array( '&#91;', '&#93;' );
+		$string = str_replace( $find, $replace, $string );
+		return $string;
+	}
+
 
 
 

--- a/includes/class-common.php
+++ b/includes/class-common.php
@@ -1502,9 +1502,10 @@ class GVCommon {
     }
 
 	/**
-	 * Inspired on \GFCommon::encode_shortcodes
-	 * @param $string
-	 * @return $string
+	 * Inspired on \GFCommon::encode_shortcodes, reverse the encoding by replacing the ascii characters by the shortcode brackets
+	 * @since 1.16.5
+	 * @param string $string Input string to decode
+	 * @return string $string Output string
 	 */
 	public static function decode_shortcodes( $string ) {
 		$replace = array( '[', ']' );

--- a/includes/class-common.php
+++ b/includes/class-common.php
@@ -1518,9 +1518,10 @@ class GVCommon {
 	 * @return string $string Output string
 	 */
 	public static function decode_shortcodes( $string ) {
-		$replace = array( '[', ']' );
-		$find = array( '&#91;', '&#93;' );
+		$replace = array( '[', ']', '"' );
+		$find = array( '&#91;', '&#93;', '&quot;' );
 		$string = str_replace( $find, $replace, $string );
+
 		return $string;
 	}
 

--- a/templates/fields/custom.php
+++ b/templates/fields/custom.php
@@ -36,12 +36,21 @@ if( empty( $field_settings['content'] ) ) {
 // Replace the variables
 $content = GravityView_API::replace_variables( $field_settings['content'], $form, $entry );
 
+/**
+ * @filter `gravityview/fields/custom/decode_shortcodes` Decode brackets in shortcodes
+ * @since 1.16.5
+ * @param boolean $decode If content contains merge tags then it triggers the decoding
+ * @param string $content HTML content of field
+ */
+if( apply_filters( 'gravityview/fields/custom/decode_shortcodes', $content != $field_settings['content'], $content ) ) {
+	$content = GVCommon::decode_shortcodes( $content );
+}
+
 // Add paragraphs?
 if( !empty( $field_settings['wpautop'] ) ) {
-
 	$content = wpautop( $content );
-
 }
+
 
 /**
  * @filter `gravityview/fields/custom/content_after` Modify Custom Content field output after Merge Tag variables get replaced, before shortcodes get processed

--- a/templates/fields/custom.php
+++ b/templates/fields/custom.php
@@ -39,10 +39,10 @@ $content = GravityView_API::replace_variables( $field_settings['content'], $form
 /**
  * @filter `gravityview/fields/custom/decode_shortcodes` Decode brackets in shortcodes
  * @since 1.16.5
- * @param boolean $decode If content contains merge tags then it triggers the decoding
+ * @param boolean $decode Enable/Disable decoding of brackets in the content (default: false)
  * @param string $content HTML content of field
  */
-if( apply_filters( 'gravityview/fields/custom/decode_shortcodes', $content != $field_settings['content'], $content ) ) {
+if( apply_filters( 'gravityview/fields/custom/decode_shortcodes', false, $content ) ) {
 	$content = GVCommon::decode_shortcodes( $content );
 }
 
@@ -50,7 +50,6 @@ if( apply_filters( 'gravityview/fields/custom/decode_shortcodes', $content != $f
 if( !empty( $field_settings['wpautop'] ) ) {
 	$content = wpautop( $content );
 }
-
 
 /**
  * @filter `gravityview/fields/custom/content_after` Modify Custom Content field output after Merge Tag variables get replaced, before shortcodes get processed


### PR DESCRIPTION
When using merge tags inside a custom content field and if the original content contains brackets “[]” they are encoded by GF. We need to decode them before running the do_shortcode.
@zackkatz: do you agree with this approach of decoding only if merge tags are present, or should we decode by default ?