### PR TITLE
Fix/opt in approved meta

### DIFF
--- a/includes/class-admin-approve-entries.php
+++ b/includes/class-admin-approve-entries.php
@@ -387,6 +387,12 @@ class GravityView_Admin_ApproveEntries {
 	 */
 	private static function update_approved_meta( $entry_id, $is_approved ) {
 
+		/**
+		 * Make sure that the "User Opt-in" and the Admin Approve/Reject entry set the same meta value
+		 * @since 1.16.6
+		 */
+		$is_approved = empty( $is_approved ) ? 0 : 'Approved';
+
 		// update entry meta
 		if( function_exists('gform_update_meta') ) {
 

--- a/includes/class-admin-approve-entries.php
+++ b/includes/class-admin-approve-entries.php
@@ -40,8 +40,12 @@ class GravityView_Admin_ApproveEntries {
 		// process ajax approve entry requests
 		add_action('wp_ajax_gv_update_approved', array( $this, 'ajax_update_approved'));
 
+		// when using the User opt-in field, check on entry submission
+		add_action( 'gform_after_submission', array( $this, 'after_submission' ), 10, 2 );
+
 		// in case entry is edited (on admin or frontend)
 		add_action( 'gform_after_update_entry', array( $this, 'after_update_entry_update_approved_meta' ), 10, 2);
+
 
 		add_filter( 'gravityview_tooltips', array( $this, 'tooltips' ) );
 
@@ -350,6 +354,21 @@ class GravityView_Admin_ApproveEntries {
 
 	}
 
+
+	/**
+	 * Update the is_approved meta whenever the entry is submitted (and it contains a User Opt-in field)
+	 *
+	 * @since 1.16.6
+	 *
+	 * @param $entry array Gravity Forms entry object
+	 * @param $form array Gravity Forms form object
+	 */
+	public function after_submission( $entry, $form ) {
+		$this->after_update_entry_update_approved_meta( $form , $entry['id'] );
+	}
+
+
+
 	/**
 	 * Update the is_approved meta whenever the entry is updated
 	 *
@@ -359,7 +378,7 @@ class GravityView_Admin_ApproveEntries {
 	 * @param  int $entry_id ID of the Gravity Forms entry
 	 * @return void
 	 */
-	public static function after_update_entry_update_approved_meta( $form, $entry_id = NULL ) {
+	public function after_update_entry_update_approved_meta( $form, $entry_id = NULL ) {
 
 		$approvedcolumn = self::get_approved_column( $form['id'] );
 

--- a/includes/fields/class-gravityview-field-phone.php
+++ b/includes/fields/class-gravityview-field-phone.php
@@ -20,6 +20,34 @@ class GravityView_Field_Phone extends GravityView_Field {
 		parent::__construct();
 	}
 
+	/**
+	 * Add option to link phone number
+	 *
+	 * @since TODO
+	 *
+	 * @param array $field_options
+	 * @param string $template_id
+	 * @param string $field_id
+	 * @param string $context
+	 * @param string $input_type
+	 *
+	 * @return array
+	 */
+	function field_options( $field_options, $template_id, $field_id, $context, $input_type ) {
+
+		if( 'edit' === $context ) {
+			return $field_options;
+		}
+
+		$field_options['link_phone'] = array(
+	        'type' => 'checkbox',
+	        'label' => __( 'Make Phone Number Clickable', 'gravityview' ),
+	        'desc' => __( 'Allow dialing a number by clicking it?', 'gravityview'),
+	        'value' => true,
+        );
+
+		return $field_options;
+	}
 }
 
 new GravityView_Field_Phone;

--- a/readme.txt
+++ b/readme.txt
@@ -21,6 +21,7 @@ Beautifully display your Gravity Forms entries. Learn more on [gravityview.co](h
 == Changelog ==
 
 * Added: Option to make Phone numbers click-to-call
+* Fixed: When using the User Opt-in field together with the view setting "Show Only Approved Entries" the entries weren't showing.
 
 = 1.16.5.1 on April 7 =
 

--- a/readme.txt
+++ b/readme.txt
@@ -20,6 +20,8 @@ Beautifully display your Gravity Forms entries. Learn more on [gravityview.co](h
 
 == Changelog ==
 
+* Added: Option to make Phone numbers click-to-call
+
 = 1.16.5 on April 6 =
 
 * Fixed: Search Bar inputs not displaying for Number fields

--- a/templates/fields/phone.php
+++ b/templates/fields/phone.php
@@ -1,0 +1,25 @@
+<?php
+/**
+ * Display the phone field type
+ *
+ * @since TODO
+ *
+ * @package GravityView
+ * @subpackage GravityView/templates/fields
+ */
+
+$gravityview_view = GravityView_View::getInstance();
+
+/**
+ * @var double|int|string $value
+ * @var double|int|string $display_value
+ */
+extract( $gravityview_view->getCurrentField() );
+
+$value = esc_attr( $value );
+
+if( ! empty( $field_settings['link_phone'] ) ) {
+	echo "<a href='tel:{$value}'>$value</a>";
+} else {
+	echo $value;
+}


### PR DESCRIPTION
Fixes the User Opt-in field when used to “approve” entries:
* When entry is submitted
* is_approved meta value