### PR TITLE
fix conflict with Gravity Flow

### DIFF
--- a/includes/extensions/edit-entry/class-edit-entry-render.php
+++ b/includes/extensions/edit-entry/class-edit-entry-render.php
@@ -183,7 +183,7 @@ class GravityView_Edit_Entry_Render {
      */
     public function is_edit_entry() {
 
-        $gf_page = function_exists('rgpost') && ( 'entry' === rgget( 'view' ) && isset( $_GET['edit'] ) || rgpost( 'action' ) === 'update' );
+        $gf_page = function_exists('rgpost') && ( 'entry' === rgget( 'view' ) && isset( $_GET['edit'] ) );
 
         return $gf_page;
     }


### PR DESCRIPTION
When the GravityView shortcode is inside an HTML field during a Gravity Flow entry update then GravityView_Edit_Entry_Render::is_edit_entry() will always return true. Removing the check for the action fixes this issue but I’ve not tested the impact extensively.