### PR TITLE
More plugin initialization

### DIFF
--- a/future/includes/class-gv-core.php
+++ b/future/includes/class-gv-core.php
@@ -80,6 +80,14 @@ final class Core {
 		if ( ! $this->plugin->is_compatible() ) {
 			return;
 		}
+
+		/** Register the gravityview post type upon WordPress core init. */
+		require_once $this->plugin->dir( 'future/includes/class-gv-view.php' );
+		add_action( 'init', array( '\GV\View', 'register_post_type' ) );
+
+		/** Add rewrite endpoint for single-entry URLs. */
+		require_once $this->plugin->dir( 'future/includes/class-gv-entry.php' );
+		add_action( 'init', array( '\GV\Entry', 'add_rewrite_endpoint' ) );
 	}
 
 	private function __clone() { }

--- a/future/includes/class-gv-core.php
+++ b/future/includes/class-gv-core.php
@@ -56,6 +56,7 @@ final class Core {
 	 * @return void
 	 */
 	private function __construct() {
+		self::$__instance = $this;
 		$this->init();
 	}
 
@@ -68,7 +69,17 @@ final class Core {
 	 */
 	private function init() {
 		require_once dirname( __FILE__ ) . '/class-gv-plugin.php';
-		$this->plugin = \GV\Plugin::get();
+		$this->plugin = Plugin::get();
+
+		/**
+		 * Stop all further functionality from loading if the WordPress
+		 * plugin is incompatible with the current environment.
+		 *
+		 * @todo Output incompatibility notices.
+		 */
+		if ( ! $this->plugin->is_compatible() ) {
+			return;
+		}
 	}
 
 	private function __clone() { }

--- a/future/includes/class-gv-entry.php
+++ b/future/includes/class-gv-entry.php
@@ -1,0 +1,50 @@
+<?php
+namespace GV;
+
+/** If this file is called directly, abort. */
+if ( ! defined( 'GRAVITYVIEW_DIR' ) )
+	die();
+
+/**
+ * The base Entry class.
+ *
+ * Contains all entry data and some processing and logic rules.
+ */
+class Entry {
+	
+	/**
+	 * Adds the necessary rewrites for single Entries.
+	 *
+	 * @internal
+	 * @return void
+	 */
+	public static function add_rewrite_endpoint() {
+		global $wp_rewrite;
+
+		$endpoint = self::get_endpoint_name();
+
+		/** Let's make sure the endpoint array is not polluted. */
+		if ( in_array( array( EP_ALL, $endpoint, $endpoint ), $wp_rewrite->endpoints ) )
+			return;
+
+		add_rewrite_endpoint( $endpoint, EP_ALL );
+	}
+
+	/**
+	 * Return the endpoint name for a single Entry.
+	 *
+	 * Also used as the query_var for the time being.
+	 *
+	 * @internal
+	 * @return string The name. Default: "entry"
+	 */
+	public static function get_endpoint_name() {
+		/**
+		 * @filter `gravityview_directory_endpoint` Change the slug used for single entries
+		 * @param[in,out] string $endpoint Slug to use when accessing single entry. Default: `entry`
+		 */
+		$endpoint = apply_filters( 'gravityview_directory_endpoint', 'entry' );
+
+		return sanitize_title( $endpoint );
+	}
+}

--- a/future/includes/class-gv-plugin.php
+++ b/future/includes/class-gv-plugin.php
@@ -88,6 +88,13 @@ final class Plugin {
 	 * @return void
 	 */
 	private function init() {
+		/**
+		 * Stop all further functionality from loading if the WordPress
+		 * plugin is incompatible with the current environment.
+		 */
+		if ( ! $this->is_compatible() )
+			return;
+
 		/** Register hooks that are fired when the plugin is activated and deactivated. */
 		register_activation_hook( $this->dir( 'gravityview.php' ), array( $this, 'activate' ) );
 		register_deactivation_hook( $this->dir( 'gravityview.php' ), array( $this, 'deactivate' ) );
@@ -100,6 +107,7 @@ final class Plugin {
 	 * @return void
 	 */
 	public function activate() {
+		flush_rewrite_rules();
 	}
 
 	/**
@@ -109,6 +117,7 @@ final class Plugin {
 	 * @return void
 	 */
 	public function deactivate() {
+		flush_rewrite_rules();
 	}
 
 	/**

--- a/future/includes/class-gv-plugin.php
+++ b/future/includes/class-gv-plugin.php
@@ -108,6 +108,8 @@ final class Plugin {
 	 */
 	public function activate() {
 		flush_rewrite_rules();
+
+		update_option( 'gv_version', \GravityView_Plugin::version );
 	}
 
 	/**

--- a/future/includes/class-gv-view.php
+++ b/future/includes/class-gv-view.php
@@ -1,47 +1,28 @@
 <?php
+namespace GV;
+
+/** If this file is called directly, abort. */
+if ( ! defined( 'GRAVITYVIEW_DIR' ) )
+	die();
+
 /**
- * GravityView Defining Post Types and Rewrite rules
+ * The default GravityView View class.
  *
- * @package   GravityView
- * @license   GPL2+
- * @author    Katz Web Services, Inc.
- * @link      http://gravityview.co
- * @copyright Copyright 2014, Katz Web Services, Inc.
- * @deprecated
- *
- * @since 1.0.9
+ * Houses all base View functionality.
  */
-
-class GravityView_Post_Types {
-
-	function __construct() {
-		/** Deprecated. Handled by \GV\Core from here on after. */
-		if ( function_exists( 'gravityview' ) ) {
-			return;
-		}
-
-		// Load custom post types. It's a static method.
-		// Load even when invalid to allow for export
-		add_action( 'init', array( 'GravityView_Post_Types', 'init_post_types' ) );
-
-		if( GravityView_Compatibility::is_valid() ) {
-			add_action( 'init', array( 'GravityView_Post_Types', 'init_rewrite' ) );
-		}
-	}
+class View {
 
 	/**
-	 * Init plugin components such as register own custom post types
+	 * Register the gravityview WordPress Custom Post Type.
 	 *
-	 * @access public
-	 * @deprecated
-	 * @see \GV\View::register_post_type
+	 * @internal
 	 * @return void
 	 */
-	public static function init_post_types() {
+	public static function register_post_type() {
 
-		if ( function_exists( 'gravityview' ) ) {
-			return \GV\View::register_post_type();
-		}
+		/** Register only once */
+		if ( post_type_exists( 'gravityview' ) )
+			return;
 
 		/**
 		 * @filter `gravityview_is_hierarchical` Make GravityView Views hierarchical by returning TRUE
@@ -53,7 +34,7 @@ class GravityView_Post_Types {
 
 		$supports = array( 'title', 'revisions' );
 
-		if( $is_hierarchical ) {
+		if ( $is_hierarchical ) {
 			$supports[] = 'page-attributes';
 		}
 
@@ -66,7 +47,7 @@ class GravityView_Post_Types {
 		 */
 		$supports = apply_filters( 'gravityview_post_type_support', $supports, $is_hierarchical );
 
-		//Register Custom Post Type - gravityview
+		/** Register Custom Post Type - gravityview */
 		$labels = array(
 			'name'                => _x( 'Views', 'Post Type General Name', 'gravityview' ),
 			'singular_name'       => _x( 'View', 'Post Type Singular Name', 'gravityview' ),
@@ -79,7 +60,7 @@ class GravityView_Post_Types {
 			'edit_item'           => __( 'Edit View', 'gravityview' ),
 			'update_item'         => __( 'Update View', 'gravityview' ),
 			'search_items'        => __( 'Search Views', 'gravityview' ),
-			'not_found'           => GravityView_Admin::no_views_text(),
+			'not_found'           => \GravityView_Admin::no_views_text(),
 			'not_found_in_trash'  => __( 'No Views found in Trash', 'gravityview' ),
 			'filter_items_list'     => __( 'Filter Views list', 'gravityview' ),
 			'items_list_navigation' => __( 'Views list navigation', 'gravityview' ),
@@ -100,9 +81,9 @@ class GravityView_Post_Types {
 			 * @param[in,out] boolean `true`: allow Views to be accessible directly. `false`: Only allow Views to be embedded via shortcode. Default: `true`
 			 * @param int $view_id The ID of the View currently being requested. `0` for general setting
 			 */
-			'public'              => apply_filters( 'gravityview_direct_access', GravityView_Compatibility::is_valid(), 0 ),
-			'show_ui'             => GravityView_Compatibility::is_valid(),
-			'show_in_menu'        => GravityView_Compatibility::is_valid(),
+			'public'              => apply_filters( 'gravityview_direct_access', gravityview()->plugin->is_compatible(), 0 ),
+			'show_ui'             => gravityview()->plugin->is_compatible(),
+			'show_in_menu'        => gravityview()->plugin->is_compatible(),
 			'show_in_nav_menus'   => true,
 			'show_in_admin_bar'   => true,
 			'menu_position'       => 17,
@@ -128,51 +109,5 @@ class GravityView_Post_Types {
 		);
 
 		register_post_type( 'gravityview', $args );
-
 	}
-
-	/**
-	 * Register rewrite rules to capture the single entry view
-	 *
-	 * @access public
-	 * @deprecated
-	 * @see \GV\Entry::add_rewrite_endpoint
-	 * @return void
-	 */
-	public static function init_rewrite() {
-
-		if ( function_exists( 'gravityview' ) ) {
-			return \GV\Entry::add_rewrite_endpoint();
-		}
-
-		$endpoint = self::get_entry_var_name();
-
-		//add_permastruct( "{$endpoint}", $endpoint.'/%'.$endpoint.'%/?', true);
-		add_rewrite_endpoint( "{$endpoint}", EP_ALL );
-	}
-
-	/**
-	 * Return the query var / end point name for the entry
-	 *
-	 * @access public
-	 * @deprecated
-	 * @see \GV\Entry::get_endpoint_name
-	 * @return string Default: "entry"
-	 */
-	public static function get_entry_var_name() {
-		if ( function_exists( 'gravityview' ) ) {
-			return \GV\Entry::get_endpoint_name();
-		}
-
-		/**
-		 * @filter `gravityview_directory_endpoint` Change the slug used for single entries
-		 * @param[in,out] string $endpoint Slug to use when accessing single entry. Default: `entry`
-		 */
-		$endpoint = apply_filters( 'gravityview_directory_endpoint', 'entry' );
-
-		return sanitize_title( $endpoint );
-	}
-
 }
-
-new GravityView_Post_Types;

--- a/gravityview.php
+++ b/gravityview.php
@@ -220,7 +220,10 @@ final class GravityView_Plugin {
 		// register rewrite rules
 		GravityView_Post_Types::init_rewrite();
 
-		flush_rewrite_rules();
+		/** Deprecate. Handled in \GV\Plugin::activate now. */
+		if ( ! function_exists( 'gravityview' ) ) {
+			flush_rewrite_rules();
+		}
 
 		// Update the current GV version
 		update_option( 'gv_version', self::version );
@@ -239,11 +242,13 @@ final class GravityView_Plugin {
 	 * Plugin deactivate function.
 	 *
 	 * @access public
-	 * @static
+	 * @deprecated
 	 * @return void
 	 */
 	public static function deactivate() {
-		flush_rewrite_rules();
+		if ( ! function_exists( 'gravityview' ) ) {
+			flush_rewrite_rules();
+		}
 	}
 
 	/**

--- a/gravityview.php
+++ b/gravityview.php
@@ -229,10 +229,10 @@ final class GravityView_Plugin {
 		/** Deprecate. Handled in \GV\Plugin::activate now. */
 		if ( ! function_exists( 'gravityview' ) ) {
 			flush_rewrite_rules();
-		}
 
-		// Update the current GV version
-		update_option( 'gv_version', self::version );
+			// Update the current GV version
+			update_option( 'gv_version', self::version );
+		}
 
 		// Add the transient to redirect to configuration page
 		set_transient( '_gv_activation_redirect', true, 60 );

--- a/gravityview.php
+++ b/gravityview.php
@@ -214,11 +214,17 @@ final class GravityView_Plugin {
 
 		self::require_files();
 
-		// register post types
-		GravityView_Post_Types::init_post_types();
+		/** Deprecate in favor of \GV\View::register_post_type. */
+		if ( ! function_exists( 'gravityview' ) ) {
+			// register post types
+			GravityView_Post_Types::init_post_types();
+		}
 
-		// register rewrite rules
-		GravityView_Post_Types::init_rewrite();
+		/** Deprecate in favor of \GV\View::add_rewrite_endpoint. */
+		if ( ! function_exists( 'gravityview' ) ) {
+			// register rewrite rules
+			GravityView_Post_Types::init_rewrite();
+		}
 
 		/** Deprecate. Handled in \GV\Plugin::activate now. */
 		if ( ! function_exists( 'gravityview' ) ) {

--- a/includes/class-api.php
+++ b/includes/class-api.php
@@ -660,7 +660,12 @@ class GravityView_API {
 			return '';
 		}
 
-		$query_arg_name = GravityView_Post_Types::get_entry_var_name();
+		if ( function_exists( 'gravityview' ) ) {
+			$query_arg_name = \GV\Entry::get_endpoint_name();
+		} else {
+			/** Deprecated. Use \GV\Entry::get_endpoint_name instead. */
+			$query_arg_name = GravityView_Post_Types::get_entry_var_name();
+		}
 
 		$entry_slug = self::get_entry_slug( $entry['id'], $entry );
 

--- a/includes/class-frontend-views.php
+++ b/includes/class-frontend-views.php
@@ -700,7 +700,7 @@ class GravityView_frontend {
 			/**
 			 * @filter `gravityview_direct_access` Should Views be directly accessible, or only visible using the shortcode?
 			 * @see https://codex.wordpress.org/Function_Reference/register_post_type#public
-			 * @see GravityView_Post_Types::init_post_types
+			 * @see \GV\Entry::get_endpoint_name
 			 * @since 1.15.2
 			 * @param[in,out] boolean `true`: allow Views to be accessible directly. `false`: Only allow Views to be embedded via shortcode. Default: `true`
 			 * @param int $view_id The ID of the View currently being requested. `0` for general setting
@@ -1351,7 +1351,12 @@ class GravityView_frontend {
 	 */
 	public static function is_single_entry() {
 
-		$var_name = GravityView_Post_Types::get_entry_var_name();
+		if ( function_exists( 'gravityview' ) ) {
+			$var_name = \GV\Entry::get_endpoint_name();
+		} else {
+			/** Deprecated. Use \GV\Entry::get_endpoint_name instead. */
+			$var_name = GravityView_Post_Types::get_entry_var_name();
+		}
 
 		$single_entry = get_query_var( $var_name );
 

--- a/includes/class-oembed.php
+++ b/includes/class-oembed.php
@@ -74,7 +74,12 @@ class GravityView_oEmbed {
 	 */
 	private function get_handler_regex() {
 
-		$entry_var_name = GravityView_Post_Types::get_entry_var_name();
+		if ( function_exists( 'gravityview' ) ) {
+			$entry_var_name = \GV\Entry::get_endpoint_name();
+		} else {
+			/** Deprecated. Use \GV\Entry::get_endpoint_name instead. */
+			$entry_var_name = GravityView_Post_Types::get_entry_var_name();
+		}
 
 		/**
 		 * @filter `gravityview_slug` Modify the url part for a View. [Read the doc](http://docs.gravityview.co/article/62-changing-the-view-slug)

--- a/includes/plugin-and-theme-hooks/abstract-gravityview-plugin-and-theme-hooks.php
+++ b/includes/plugin-and-theme-hooks/abstract-gravityview-plugin-and-theme-hooks.php
@@ -65,7 +65,7 @@ abstract class GravityView_Plugin_and_Theme_Hooks {
 
 	/**
 	 * Define features in the admin editor used by the theme or plugin to be used when registering the GravityView post type
-	 * @see GravityView_Post_Types::init_post_types
+	 * @see \GV\Entry::get_endpoint_name
 	 * @since 1.15.2
 	 * @type array
 	 */

--- a/tests/unit-tests/GravityView_Future_Test.php
+++ b/tests/unit-tests/GravityView_Future_Test.php
@@ -108,7 +108,7 @@ class GVFuture_Test extends GV_UnitTestCase {
 		$this->assertNotEmpty( $entry_enpoint, 'Single Entry endpoint not registered.' );
 		\GV\Entry::add_rewrite_endpoint();
 		\GV\Entry::add_rewrite_endpoint();
-		GravityView_Post_Types::init_rewrite(); /** Deprecated */
+		GravityView_Post_Types::init_rewrite(); /** Deprecated, but an alias. */
 		$this->assertCount( 1, $entry_enpoint, 'Single Entry endpoint registered more than once.' );
 
 		/** Deprecated back-compatibility insurance. */
@@ -119,5 +119,16 @@ class GVFuture_Test extends GV_UnitTestCase {
 
 		/** Make sure is_single_entry works without error, too. Uses \GV\Entry::get_endpoint_name */
 		$this->assertFalse( GravityView_frontend::is_single_entry() );
+	}
+
+	/**
+	 * @covers \GV\Plugin::activate()
+	 */
+	function test_plugin_activate() {
+		/** Trigger an activation. By default, during tests these are not triggered. */
+		GravityView_Plugin::activate();
+		gravityview()->plugin->activate(); /** Deprecated. */
+
+		$this->assertEquals( get_option( 'gv_version' ), GravityView_Plugin::version );
 	}
 }

--- a/tests/unit-tests/GravityView_Future_Test.php
+++ b/tests/unit-tests/GravityView_Future_Test.php
@@ -95,4 +95,29 @@ class GVFuture_Test extends GV_UnitTestCase {
 		$GLOBALS['GRAVITYVIEW_TESTS_WP_VERSION_OVERRIDE'] = '3.0';
 		$this->assertFalse( GravityView_Compatibility::check_wordpress() );
 	}
+
+	/**
+	 * @covers \GV\Entry::add_rewrite_endpoint()
+	 * @covers \GV\Entry::get_endpoint_name()
+	 */
+	function test_entry_endpoint_rewrite_name() {
+		$entry_enpoint = array_filter( $GLOBALS['wp_rewrite']->endpoints, function( $endpoint ) {
+			return $endpoint === array( EP_ALL, 'entry', 'entry' );
+		} );
+
+		$this->assertNotEmpty( $entry_enpoint, 'Single Entry endpoint not registered.' );
+		\GV\Entry::add_rewrite_endpoint();
+		\GV\Entry::add_rewrite_endpoint();
+		GravityView_Post_Types::init_rewrite(); /** Deprecated */
+		$this->assertCount( 1, $entry_enpoint, 'Single Entry endpoint registered more than once.' );
+
+		/** Deprecated back-compatibility insurance. */
+		$this->assertEquals( \GV\Entry::get_endpoint_name(), GravityView_Post_Types::get_entry_var_name() );
+
+		/** Make sure oEmbed handler registration doesn't error out with \GV\Entry::get_endpoint_name, and works. */
+		$this->assertContains( 'gravityview_entry', array_keys( $GLOBALS['wp_embed']->handlers[20000] ), 'oEmbed handler was not registered properly.' );
+
+		/** Make sure is_single_entry works without error, too. Uses \GV\Entry::get_endpoint_name */
+		$this->assertFalse( GravityView_frontend::is_single_entry() );
+	}
 }


### PR DESCRIPTION
More movement around, lots of tests, stubs, stub tests. Most parts of the plugin initialization.

We're pretty much ready to get rid of the old GravityView_Post_Types class altogether now. Of course we'll wait for hard deprecation, and removal milestones before doing this.