### PR TITLE
Fix `\GV\View::by_id` dependence on global state

### DIFF
--- a/future/includes/class-gv-view.php
+++ b/future/includes/class-gv-view.php
@@ -282,14 +282,14 @@ class View implements \ArrayAccess {
 	 * Construct a \GV\View instance from a post ID.
 	 *
 	 * @param int|string $post_id The post ID.
-	 * @throws \InvalidArgumentException if $post is not of 'gravityview' type.
+	 * @throws \InvalidArgumentException if $post_id does not resolve to a post of non-'gravityview' type.
 	 *
 	 * @api
 	 * @since future
 	 * @return \GV\View|null An instance around this \WP_Post or null if not found.
 	 */
 	public static function by_id( $post_id ) {
-		if ( ! $post = get_post( $post_id ) ) {
+		if ( ! $post_id || ! $post = get_post( $post_id ) ) {
 			return null;
 		}
 		return self::from_post( $post );

--- a/tests/unit-tests/GravityView_Future_Test.php
+++ b/tests/unit-tests/GravityView_Future_Test.php
@@ -229,6 +229,14 @@ class GVFuture_Test extends GV_UnitTestCase {
 			$expectedException = $e;
 		}
 		$this->assertInstanceOf( '\InvalidArgumentException', $expectedException );
+
+		/** Disregard global state with a null passed */
+		global $post;
+		$post = $this->factory->post->create_and_get();
+
+		$this->assertNull( \GV\View::by_id( null ) );
+
+		unset( $post );
 	}
 
 	/**


### PR DESCRIPTION
`get_post` relies on a the `$post` global to resolve a `$post_id` set to
NULL. Which tries to retrieve the current global `$post` object when
called through `\GV\View::by_id` with NULL given in turn.

Make sure we don't rely on the global `$post` when trying to retrieve a
`\GV\View` by a falsey ID (0, null, false, '', etc.)

Discovered as underlying problem in issue #870, and fixes it.