### PR TITLE
Resolves conflict with registered Gravity PDF query vars

### DIFF
--- a/includes/class-frontend-views.php
+++ b/includes/class-frontend-views.php
@@ -299,7 +299,7 @@ class GravityView_frontend {
 			}
 
 			// this is where will break from core wordpress
-			$ignore = array( 'preview', 'page', 'paged', 'cpage' );
+			$ignore = apply_filters( 'gravityview/internal/ignored_endpoints', array( 'preview', 'page', 'paged', 'cpage' ), $query );
 			$endpoints = rgobj( $wp_rewrite, 'endpoints' );
 			foreach ( (array) $endpoints as $endpoint ) {
 				$ignore[] = $endpoint[1];


### PR DESCRIPTION
Gravity PDF registers four query vars when registering their PDF endpoint. GravityView seems to pick up the 'lid' and 'action' parameters when checking if the current page is the home page. This causes it to skip the query modifications and displays the incorrect Gravity Form when an entry is edited on a front page. This commit includes these vars in the ignore list so GravityView can happily do its thing.

P.s may want to add a filter for the ignore list so others can easily add to it.