### PR TITLE
Version 1.22.4

### DIFF
--- a/gravityview.php
+++ b/gravityview.php
@@ -3,7 +3,7 @@
  * Plugin Name:       	GravityView
  * Plugin URI:        	https://gravityview.co
  * Description:       	The best, easiest way to display Gravity Forms entries on your website.
- * Version:          	1.22.3
+ * Version:          	1.22.4
  * Author:            	GravityView
  * Author URI:        	https://gravityview.co
  * Text Domain:       	gravityview
@@ -79,7 +79,7 @@ require GRAVITYVIEW_DIR . 'future/loader.php';
  */
 final class GravityView_Plugin {
 
-	const version = '1.22.3';
+	const version = '1.22.4';
 
 	private static $instance;
 

--- a/includes/admin/metaboxes/class-gravityview-admin-metaboxes.php
+++ b/includes/admin/metaboxes/class-gravityview-admin-metaboxes.php
@@ -297,10 +297,14 @@ class GravityView_Admin_Metaboxes {
 		global $post;
 
 		// Only show this on GravityView post types.
-		if( false === gravityview_is_admin_page() ) { return; }
+		if( false === gravityview_is_admin_page() ) {
+			return;
+		}
 
 		// If the View hasn't been configured yet, don't show embed shortcode
-		if( !gravityview_get_directory_fields( $post->ID ) ) { return; }
+		if( ! gravityview_get_directory_fields( $post->ID ) && ! gravityview_get_directory_widgets( $post->ID ) ) {
+			return;
+		}
 
 		include self::$metaboxes_dir . 'views/shortcode-hint.php';
 	}

--- a/includes/class-admin-welcome.php
+++ b/includes/class-admin-welcome.php
@@ -254,11 +254,10 @@ class GravityView_Welcome {
 
 				<div class="feature-section col two-col" style="margin:0; padding: 0;">
 					<div class="col col-1">
-                        <div class="media-container"><img alt="[else if]" src="<?php echo plugins_url( 'assets/images/screenshots/else-if.png', GRAVITYVIEW_FILE ); ?>" style="border: none"></div>
-                        <h4 class="higher">The <code>[else]</code> shortcode now supports additional logic!</h4>
-                        <p>Before, you would have to use multiple <code>[gvlogic]</code> shortcodes in your <a href="https://docs.gravityview.co/article/111-using-the-custom-content-field">Custom Content fields</a>.</p>
-                        <p>Now, you can use the <code>[else]</code> shortcode like this: <code>[else if="{Field Value:1}" is="Example"]</code>.</p>
-                        <p><a href="https://docs.gravityview.co/article/252-gvlogic-shortcode" class="button-primary button button-large">Read more about the <code>[gvlogic]</code> shortcode</a></p>
+                        <div class="media-container"><iframe width="489" height="275" src="https://www.youtube-nocookie.com/embed/ANEiBP1tON0?rel=0&amp;showinfo=0" frameborder="0" allow="autoplay; encrypted-media" allowfullscreen></iframe></div>
+                        <h4 class="higher"><abbr title="Do It Yourself">DIY</abbr> Layout</h4>
+                        <p>The View layout tool for designers &amp; developers. Included in Galactic licenses. DIY allows you to define your own CSS and HTML structure instead of needing to modify our predefined layouts to fit your needs.</p>
+                        <p><a href="https://gravityview.co/extensions/diy-layout/?utm_source=admin-welcome&utm_medium=plugin&utm_campaign=whats-new&utm_content=button" class="button-primary button button-large">Learn More &amp; Get DIY Now</a></p>
                     </div>
                     <div class="col col-2">
                         <div class="media-container"><a href="<?php echo esc_url( admin_url( 'edit.php?post_type=gravityview&page=gravityview_settings' ) ); ?>"><img alt="Beta!" src="<?php echo plugins_url( 'assets/images/screenshots/beta-program.jpg', GRAVITYVIEW_FILE ); ?>" style="border: none"></a></div>
@@ -271,6 +270,21 @@ class GravityView_Welcome {
 				<div class="headline-feature" style="max-width: 100%">
 					<h2 style="border-bottom: 1px solid #ccc; padding-bottom: 1em; margin-bottom: 0;"><?php esc_html_e( 'What&rsquo;s New', 'gravityview' ); ?></h2>
 				</div>
+
+                <h3>1.22.4 on January 16, 2018</h3>
+
+                <ul>
+                    <li>Adds support for <a href="https://gravityview.co/extensions/diy-layout/">DIY Layout</a>, a layout for designers &amp; developers to take full advantage of GravityView</li>
+                    <li>Tweak: Show &quot;Embed Shortcode&quot; helper if a View has widgets configured but not Fields</li>
+                    <li>Fixed: <code>tabindex</code> not properly set for Update/Cancel/Delete buttons in Edit Entry</li>
+                    <li>Fixed: Hide Yoast SEO Content &amp; SEO Analysis functionality when editing a View</li>
+                </ul>
+
+                <p><strong>Developer Updates:</strong></p>
+
+                <ul>
+                    <li>Add <code>$nl2br</code>, <code>$format</code>, <code>$aux_data</code> parameters to <code>GravityView_API::replace_variables()</code> to be consistent with <code>GFCommon::replace_variables()</code></li>
+                </ul>
 
                 <h3>1.22.3 on December 21, 2017</h3>
 

--- a/includes/class-api.php
+++ b/includes/class-api.php
@@ -93,14 +93,20 @@ class GravityView_API {
 	 * Alias for GravityView_Merge_Tags::replace_variables()
 	 *
 	 * @see GravityView_Merge_Tags::replace_variables() Moved in 1.8.4
+	 * @since 1.22.4 - Added $nl2br, $format, $aux_data args
 	 *
-	 * @param  string      $text       Text to replace variables in
-	 * @param  array      $form        GF Form array
+	 * @param  string     $text         Text to replace variables in
+	 * @param  array      $form         GF Form array
 	 * @param  array      $entry        GF Entry array
-	 * @return string                  Text with variables maybe replaced
+	 * @param  bool       $url_encode   Pass return value through `url_encode()`
+	 * @param  bool       $esc_html     Pass return value through `esc_html()`
+	 * @param  bool       $nl2br        Convert newlines to <br> HTML tags
+	 * @param  string     $format       The format requested for the location the merge is being used. Possible values: html, text or url.
+	 * @param  array      $aux_data     Additional data to be used to replace merge tags {@see https://www.gravityhelp.com/documentation/article/gform_merge_tag_data/}
+	 * @return string                   Text with variables maybe replaced
 	 */
-	public static function replace_variables( $text, $form = array(), $entry = array() ) {
-		return GravityView_Merge_Tags::replace_variables( $text, $form, $entry );
+	public static function replace_variables( $text, $form = array(), $entry = array(), $url_encode = false, $esc_html = true, $nl2br = true, $format = 'html', $aux_data = array() ) {
+		return GravityView_Merge_Tags::replace_variables( $text, $form, $entry, $url_encode, $esc_html, $nl2br, $format, $aux_data );
 	}
 
 	/**

--- a/includes/class-gravityview-merge-tags.php
+++ b/includes/class-gravityview-merge-tags.php
@@ -163,15 +163,19 @@ class GravityView_Merge_Tags {
 	 * to disable or enable replacements.
 	 * @since 1.8.4 - Moved to GravityView_Merge_Tags
 	 * @since 1.15.1 - Add support for $url_encode and $esc_html arguments
+	 * @since 1.22.4 - Added $nl2br, $format, $aux_data args
 	 *
 	 * @param  string           $text       Text to replace variables in
 	 * @param  array            $form        GF Form array
 	 * @param  array            $entry        GF Entry array
 	 * @param  bool             $url_encode   Pass return value through `url_encode()`
 	 * @param  bool             $esc_html     Pass return value through `esc_html()`
+	 * @param  bool             $nl2br        Convert newlines to <br> HTML tags
+	 * @param  string           $format       The format requested for the location the merge is being used. Possible values: html, text or url.
+	 * @param  array            $aux_data     Additional data to be used to replace merge tags {@see https://www.gravityhelp.com/documentation/article/gform_merge_tag_data/}
 	 * @return string           Text with variables maybe replaced
 	 */
-	public static function replace_variables($text, $form = array(), $entry = array(), $url_encode = false, $esc_html = true ) {
+	public static function replace_variables($text, $form = array(), $entry = array(), $url_encode = false, $esc_html = true, $nl2br = true, $format = 'html', $aux_data = array() ) {
 
 		/**
 		 * @filter `gravityview_do_replace_variables` Turn off merge tag variable replacements.\n
@@ -192,7 +196,7 @@ class GravityView_Merge_Tags {
 		/**
 		 * Make sure the required keys are set for GFCommon::replace_variables
 		 *
-		 * @internal Reported to GF Support on 12/3
+		 * @internal Reported to GF Support on 12/3/2016
 		 * @internal Fixed $form['title'] in Gravity Forms
 		 * @see      https://github.com/gravityforms/gravityforms/pull/27/files
 		 */
@@ -200,7 +204,7 @@ class GravityView_Merge_Tags {
 		$form['id']     = isset( $form['id'] ) ? $form['id'] : '';
 		$form['fields'] = isset( $form['fields'] ) ? $form['fields'] : array();
 
-		return GFCommon::replace_variables( $text, $form, $entry, $url_encode, $esc_html );
+		return GFCommon::replace_variables( $text, $form, $entry, $url_encode, $esc_html, $nl2br, $format, $aux_data );
 	}
 
 	/**

--- a/includes/extensions/delete-entry/class-delete-entry.php
+++ b/includes/extensions/delete-entry/class-delete-entry.php
@@ -287,7 +287,7 @@ final class GravityView_Delete_Entry {
 
 		$attributes = array(
 			'class' => 'btn btn-sm button button-small alignright pull-right btn-danger gv-button-delete',
-			'tabindex' => '5',
+			'tabindex' => ( GFCommon::$tab_index ++ ),
 			'onclick' => self::get_confirm_dialog(),
 		);
 

--- a/includes/extensions/edit-entry/partials/form-buttons.php
+++ b/includes/extensions/edit-entry/partials/form-buttons.php
@@ -42,10 +42,12 @@
 	 */
 	$labels = apply_filters( 'gravityview/edit_entry/button_labels', $labels, $object->form, $object->entry, $object->view_id );
 
+	$update_tabindex  = GFCommon::get_tabindex();
+	$cancel_tabindex  = GFCommon::get_tabindex();
 	?>
-	<input id="gform_submit_button_<?php echo esc_attr( $object->form['id'] ); ?>" class="btn btn-lg button button-large gform_button button-primary gv-button-update" type="submit" tabindex="4" value="<?php echo esc_attr( $labels['submit'] ); ?>" name="save" />
+	<input id="gform_submit_button_<?php echo esc_attr( $object->form['id'] ); ?>" class="btn btn-lg button button-large gform_button button-primary gv-button-update" type="submit" <?php echo $update_tabindex; ?> value="<?php echo esc_attr( $labels['submit'] ); ?>" name="save" />
 
-	<a class="btn btn-sm button button-small gv-button-cancel" tabindex="5" href="<?php echo esc_url( $back_link ); ?>"><?php echo esc_attr( $labels['cancel'] ); ?></a>
+	<a class="btn btn-sm button button-small gv-button-cancel" <?php echo $cancel_tabindex; ?> href="<?php echo esc_url( $back_link ); ?>"><?php echo esc_attr( $labels['cancel'] ); ?></a>
 	<?php
 
 	/**

--- a/includes/plugin-and-theme-hooks/class-gravityview-plugin-hooks-yoast-seo.php
+++ b/includes/plugin-and-theme-hooks/class-gravityview-plugin-hooks-yoast-seo.php
@@ -75,9 +75,27 @@ class GravityView_Plugin_Hooks_Yoast_SEO extends GravityView_Plugin_and_Theme_Ho
 			// Prevent the SEO from being checked. Eesh.
 			add_filter( 'wpseo_use_page_analysis', '__return_false' );
 
+			add_filter( 'option_wpseo', array( $this, 'disable_content_analysis' ) );
+
 			// WordPress SEO Plugin
 			add_filter( 'option_wpseo_titles', array( $this, 'hide_wordpress_seo_metabox' ) );
 		}
+	}
+
+	/**
+	 * Don't try to analyze content for Views
+	 *
+	 * @since  1.22.4
+	 * @param  array $options Existing WPSEO options array
+	 *
+	 * @return array
+	 */
+	public function disable_content_analysis( $options ) {
+
+		$options['keyword_analysis_active'] = false;
+		$options['content_analysis_active'] = false;
+
+		return $options;
 	}
 
 	/**
@@ -90,7 +108,7 @@ class GravityView_Plugin_Hooks_Yoast_SEO extends GravityView_Plugin_and_Theme_Ho
 	 * @param  array       $options WP SEO options array
 	 * @return array               Modified array if on post-new.php
 	 */
-	function hide_wordpress_seo_metabox( $options = array() ) {
+	public function hide_wordpress_seo_metabox( $options = array() ) {
 		global $pagenow;
 
 		// New View page

--- a/languages/gravityview.pot
+++ b/languages/gravityview.pot
@@ -1,14 +1,14 @@
-# Copyright (C) 2017 GravityView
+# Copyright (C) 2018 GravityView
 # This file is distributed under the GPLv2 or later.
 msgid ""
 msgstr ""
-"Project-Id-Version: GravityView 1.22.3\n"
+"Project-Id-Version: GravityView 1.22.4\n"
 "Report-Msgid-Bugs-To: https://gravityview.co/support/\n"
 "POT-Creation-Date: 2016-05-13 20:20:24+00:00\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"PO-Revision-Date: 2017-MO-DA HO:MI+ZONE\n"
+"PO-Revision-Date: 2018-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Katz Web Services, Inc. <support@katz.co>\n"
 "Language-Team: Katz Web Services, Inc. <support@katz.co>\n"
 "X-Generator: grunt-wp-i18n 0.5.4\n"
@@ -1132,19 +1132,19 @@ msgid_plural "%s Views restored from the Trash."
 msgstr[0] ""
 msgstr[1] ""
 
-#: includes/class-api.php:415
+#: includes/class-api.php:421
 msgid "This search returned no results."
 msgstr ""
 
-#: includes/class-api.php:417 includes/class-gravityview-entry-list.php:86
+#: includes/class-api.php:423 includes/class-gravityview-entry-list.php:86
 msgid "No entries match your request."
 msgstr ""
 
-#: includes/class-api.php:853
+#: includes/class-api.php:859
 msgid "&larr; Go back"
 msgstr ""
 
-#: includes/class-api.php:1163
+#: includes/class-api.php:1169
 msgid "Map It"
 msgstr ""
 

--- a/readme.txt
+++ b/readme.txt
@@ -20,9 +20,16 @@ Beautifully display your Gravity Forms entries. Learn more on [gravityview.co](h
 
 == Changelog ==
 
+= 1.22.4 on January 16, 2018 =
+
+* Adds support for [DIY Layout](https://gravityview.co/extensions/diy-layout/), a layout for designers & developers to take full advantage of GravityView
 * Tweak: Show "Embed Shortcode" helper if a View has widgets configured but not Fields
 * Fixed: `tabindex` not properly set for Update/Cancel/Delete buttons in Edit Entry
 * Fixed: Hide Yoast SEO Content & SEO Analysis functionality when editing a View
+
+__Developer Updates:__
+
+* Add `$nl2br`, `$format`, `$aux_data` parameters to `GravityView_API::replace_variables()` to be consistent with `GFCommon::replace_variables()`
 
 = 1.22.3 on December 21, 2017 =
 

--- a/readme.txt
+++ b/readme.txt
@@ -22,6 +22,7 @@ Beautifully display your Gravity Forms entries. Learn more on [gravityview.co](h
 
 * Tweak: Show "Embed Shortcode" helper if a View has widgets configured but not Fields
 * Fixed: `tabindex` not properly set for Update/Cancel/Delete buttons in Edit Entry
+* Fixed: Hide Yoast SEO Content & SEO Analysis functionality when editing a View
 
 = 1.22.3 on December 21, 2017 =
 

--- a/readme.txt
+++ b/readme.txt
@@ -21,6 +21,7 @@ Beautifully display your Gravity Forms entries. Learn more on [gravityview.co](h
 == Changelog ==
 
 * Tweak: Show "Embed Shortcode" helper if a View has widgets configured but not Fields
+* Fixed: `tabindex` not properly set for Update/Cancel/Delete buttons in Edit Entry
 
 = 1.22.3 on December 21, 2017 =
 

--- a/readme.txt
+++ b/readme.txt
@@ -20,6 +20,8 @@ Beautifully display your Gravity Forms entries. Learn more on [gravityview.co](h
 
 == Changelog ==
 
+* Tweak: Show "Embed Shortcode" helper if a View has widgets configured but not Fields
+
 = 1.22.3 on December 21, 2017 =
 
 * Added: Support for displaying files uploaded using the Gravity Forms Dropbox Addon (thanks, @mgratch and @ViewFromTheBox!)


### PR DESCRIPTION
* Adds support for [DIY Layout](https://gravityview.co/extensions/diy-layout/), a layout for designers & developers to take full advantage of GravityView
* Tweak: Show "Embed Shortcode" helper if a View has widgets configured but not Fields
* Fixed: `tabindex` not properly set for Update/Cancel/Delete buttons in Edit Entry
* Fixed: Hide Yoast SEO Content & SEO Analysis functionality when editing a View