### PR TITLE
Prevent the magic method from filtering non-string values

### DIFF
--- a/future/includes/class-gv-view.php
+++ b/future/includes/class-gv-view.php
@@ -565,10 +565,8 @@ class View implements \ArrayAccess {
 		$return = isset( $this->$key ) ? $this->$key : null;
 
 		if ( $this->post ) {
-			$filter_backup = $this->post->filter;
-			$this->post->filter = false;
-			$return = $this->post->$key;
-			$this->post->filter = $filter_backup;
+			$raw_post = $this->post->filter('raw');
+			$return = $raw_post->$key;
 		}
 
 		return $return;

--- a/future/includes/class-gv-view.php
+++ b/future/includes/class-gv-view.php
@@ -561,9 +561,16 @@ class View implements \ArrayAccess {
 	}
 
 	public function __get( $key ) {
+
+		$return = isset( $this->$key ) ? $this->$key : null;
+
 		if ( $this->post ) {
-			return $this->post->$key;
+			$filter_backup = $this->post->filter;
+			$this->post->filter = false;
+			$return = $this->post->$key;
+			$this->post->filter = $filter_backup;
 		}
-		return isset( $this->$key ) ? $this->$key : null;
+
+		return $return;
 	}
 }


### PR DESCRIPTION
Turn off post filters to prevent sanitize_post_field() from running
wp_check_invalid_utf8() and triggering "Array to string conversion"
notices.

@soulseekah You will likely want to make this look prettier