### PR TITLE
Fix/extensions framework

### DIFF
--- a/future/includes/class-gv-plugin.php
+++ b/future/includes/class-gv-plugin.php
@@ -122,7 +122,7 @@ final class Plugin {
 	 * @return void
 	 */
 	public function include_legacy_frontend( $force = false ) {
-		if ( gravityview()->request->is_admin() && ! $force ) {
+		if ( ! gravityview()->request || ( gravityview()->request->is_admin() && ! $force ) ) {
 			return;
 		}
 

--- a/gravityview.php
+++ b/gravityview.php
@@ -163,11 +163,11 @@ final class GravityView_Plugin {
 	 * Include the extension class
 	 *
 	 * @deprecated The extension framework is included by default now.
-	 *
+	 * @see \GV\Plugin
 	 * @since 1.5.1
 	 * @return void
 	 */
-	public static function include_extension_framework() {
+	protected static function include_extension_framework() {
 		gravityview()->log->notice( '\GravityView_Plugin is deprecated. Use \GV\Plugin instead.' );
 	}
 

--- a/includes/class-admin.php
+++ b/includes/class-admin.php
@@ -313,7 +313,7 @@ class GravityView_Admin {
 	 */
 	static function is_admin_page( $hook = '', $page = NULL ) {
 		gravityview()->log->warning( 'The \GravityView_Admin::is_admin_page() method is deprecated. Use gravityview()->request->is_admin' );
-		return gravityview()->request->is_admin( $hook, $page );
+		return gravityview()->request && gravityview()->request->is_admin( $hook, $page );
 	}
 }
 
@@ -331,5 +331,5 @@ new GravityView_Admin;
  */
 function gravityview_is_admin_page( $hook = '', $page = NULL ) {
 	gravityview()->log->warning( 'The gravityview_is_admin_page() function is deprecated. Use gravityview()->request->is_admin' );
-	return gravityview()->request->is_admin( $hook, $page );
+	return gravityview()->request && gravityview()->request->is_admin( $hook, $page );
 }

--- a/includes/class-frontend-views.php
+++ b/includes/class-frontend-views.php
@@ -338,7 +338,7 @@ class GravityView_frontend {
 		global $post;
 
 		// If in admin and NOT AJAX request, get outta here.
-		if ( gravityview()->request->is_admin() ) {
+		if ( ! gravityview()->request || gravityview()->request->is_admin() ) {
 			return;
 		}
 


### PR DESCRIPTION
Advanced Filter calls `gravityview_is_admin_page()` before GV is fully
loaded. The request isn't available yet.

Example error when Advanced Filters and GravityView are active, but
Gravity Forms isn't:

> ( ! ) Fatal error: Uncaught Error: Call to a member function
is_admin() on null in
/app/public/wp-content/plugins/gravityview/includes/class-admin.php on
line 316