### PR TITLE
Version 2.0.4

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -88,3 +88,4 @@ docs/html
 *.swp
 
 .idea/php.xml
+package-lock.json

--- a/.travis.yml
+++ b/.travis.yml
@@ -55,7 +55,7 @@ before_script:
   - if [[ $TRAVIS_PHP_VERSION = '7.2' && $WP_VERSION = 'latest' && $WP_MULTISITE = '0' ]]; then DO_COVERAGE=1; else DO_COVERAGE=0; fi
 
 script:
-  - if [[ $DO_COVERAGE = '1' ]]; then vendor/bin/phpunit -c phpunit.xml.dist; else vendor/bin/phpunit -c phpunit.xml.dist --no-coverage --filter test_get_view_entries_compat; fi
+  - if [[ $DO_COVERAGE = '1' ]]; then vendor/bin/phpunit -c phpunit.xml.dist; else vendor/bin/phpunit -c phpunit.xml.dist --no-coverage; fi
 
 after_script:
   - if [[ $DO_COVERAGE = '1' ]]; then wget https://scrutinizer-ci.com/ocular.phar; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -55,7 +55,7 @@ before_script:
   - if [[ $TRAVIS_PHP_VERSION = '7.2' && $WP_VERSION = 'latest' && $WP_MULTISITE = '0' ]]; then DO_COVERAGE=1; else DO_COVERAGE=0; fi
 
 script:
-  - if [[ $DO_COVERAGE = '1' ]]; then vendor/bin/phpunit -c phpunit.xml.dist; else vendor/bin/phpunit -c phpunit.xml.dist --no-coverage; fi
+  - if [[ $DO_COVERAGE = '1' ]]; then vendor/bin/phpunit -c phpunit.xml.dist; else vendor/bin/phpunit -c phpunit.xml.dist --no-coverage --filter test_get_view_entries_compat; fi
 
 after_script:
   - if [[ $DO_COVERAGE = '1' ]]; then wget https://scrutinizer-ci.com/ocular.phar; fi

--- a/future/includes/class-gv-license-handler.php
+++ b/future/includes/class-gv-license-handler.php
@@ -370,7 +370,7 @@ class License_Handler {
 	 * @param  object|null $license_data Object with license data
 	 * @return array          Modified array of content
 	 */
-	private function strings( $status = NULL, $license_data = null ) {
+	public function strings( $status = NULL, $license_data = null ) {
 		$strings = array(
 			'status' => esc_html__( 'Status', 'gravityview' ),
 			'error' => esc_html__( 'There was an error processing the request.', 'gravityview' ),

--- a/future/includes/class-gv-template-field.php
+++ b/future/includes/class-gv-template-field.php
@@ -144,20 +144,29 @@ abstract class Field_Template extends Template {
 
 		global $post;
 
+		if ( $this->field ) {
+			$inputType  = $this->field->inputType;
+			$field_type = $this->field->type;
+		}
+
+		if ( $this->view ) {
+			$view_id = $this->view->ID;
+		}
+
 		if ( $this->request && $this->request->is_view() && $post ) {
-			if ( $this->field && $this->field->type ) {
-				$specifics []= sprintf( '%spost-%d-view-%d-field-%s-%s.php', $slug_dir, $post->ID, $this->view->ID, $this->field->type, $slug_name );
-				$this->field->inputType && $specifics []= sprintf( '%spost-%d-view-%d-field-%s-%s.php', $slug_dir, $post->ID, $this->view->ID, $this->field->inputType, $slug_name );
-				$specifics []= sprintf( '%spost-%d-view-%d-field-%s.php', $slug_dir, $post->ID, $this->view->ID, $this->field->type );
-				$this->field->inputType && $specifics []= sprintf( '%spost-%d-view-%d-field-%s.php', $slug_dir, $post->ID, $this->view->ID, $this->field->inputType );
-				$specifics []= sprintf( '%spost-%d-field-%s-%s.php', $slug_dir, $post->ID, $this->field->type, $slug_name );
-				$this->field->inputType && $specifics []= sprintf( '%spost-%d-field-%s-%s.php', $slug_dir, $post->ID, $this->field->inputType, $slug_name );
-				$specifics []= sprintf( '%spost-%d-field-%s.php', $slug_dir, $post->ID, $this->field->type );
-				$this->field->inputType &&  $specifics []= sprintf( '%spost-%d-field-%s.php', $slug_dir, $post->ID, $this->field->inputType );
+			if ( $this->field && $field_type ) {
+				$specifics []= sprintf( '%spost-%d-view-%d-field-%s-%s.php', $slug_dir, $post->ID, $view_id, $field_type, $slug_name );
+				$inputType && $specifics []= sprintf( '%spost-%d-view-%d-field-%s-%s.php', $slug_dir, $post->ID, $view_id, $inputType, $slug_name );
+				$specifics []= sprintf( '%spost-%d-view-%d-field-%s.php', $slug_dir, $post->ID, $view_id, $field_type );
+				$inputType && $specifics []= sprintf( '%spost-%d-view-%d-field-%s.php', $slug_dir, $post->ID, $view_id, $inputType );
+				$specifics []= sprintf( '%spost-%d-field-%s-%s.php', $slug_dir, $post->ID, $field_type, $slug_name );
+				$inputType && $specifics []= sprintf( '%spost-%d-field-%s-%s.php', $slug_dir, $post->ID, $inputType, $slug_name );
+				$specifics []= sprintf( '%spost-%d-field-%s.php', $slug_dir, $post->ID, $field_type );
+				$inputType &&  $specifics []= sprintf( '%spost-%d-field-%s.php', $slug_dir, $post->ID, $inputType );
 			}
 
-			$specifics []= sprintf( '%spost-%d-view-%d-field-%s.php', $slug_dir, $post->ID, $this->view->ID, $slug_name );
-			$specifics []= sprintf( '%spost-%d-view-%d-field.php', $slug_dir, $post->ID, $this->view->ID );
+			$specifics []= sprintf( '%spost-%d-view-%d-field-%s.php', $slug_dir, $post->ID, $view_id, $slug_name );
+			$specifics []= sprintf( '%spost-%d-view-%d-field.php', $slug_dir, $post->ID, $view_id );
 			$specifics []= sprintf( '%spost-%d-field-%s.php', $slug_dir, $post->ID, $slug_name );
 			$specifics []= sprintf( '%spost-%d-field.php', $slug_dir, $post->ID );
 		}
@@ -170,30 +179,30 @@ abstract class Field_Template extends Template {
 				$specifics []= sprintf( '%sform-%d-field-%d.php', $slug_dir, $this->view->form->ID, $this->field->ID );
 			}
 
-			if ( $this->field->type ) {
-				$specifics []= sprintf( '%sform-%d-field-%s-%s.php', $slug_dir, $this->view->form->ID, $this->field->type, $slug_name );
-				$this->field->inputType && $specifics []= sprintf( '%sform-%d-field-%s-%s.php', $slug_dir, $this->view->form->ID, $this->field->inputType, $slug_name );
-				$specifics []= sprintf( '%sform-%d-field-%s.php', $slug_dir, $this->view->form->ID, $this->field->type );
-				$this->field->inputType && $specifics []= sprintf( '%sform-%d-field-%s.php', $slug_dir, $this->view->form->ID, $this->field->inputType );
+			if ( $field_type ) {
+				$specifics []= sprintf( '%sform-%d-field-%s-%s.php', $slug_dir, $this->view->form->ID, $field_type, $slug_name );
+				$inputType && $specifics []= sprintf( '%sform-%d-field-%s-%s.php', $slug_dir, $this->view->form->ID, $inputType, $slug_name );
+				$specifics []= sprintf( '%sform-%d-field-%s.php', $slug_dir, $this->view->form->ID, $field_type );
+				$inputType && $specifics []= sprintf( '%sform-%d-field-%s.php', $slug_dir, $this->view->form->ID, $inputType );
 
-				$specifics []= sprintf( '%sview-%d-field-%s-%s.php', $slug_dir, $this->view->ID, $this->field->type, $slug_name );
-				$this->field->inputType && $specifics []= sprintf( '%sview-%d-field-%s-%s.php', $slug_dir, $this->view->ID, $this->field->inputType, $slug_name );
-				$specifics []= sprintf( '%sview-%d-field-%s.php', $slug_dir, $this->view->ID, $this->field->type );
-				$this->field->inputType && $specifics []= sprintf( '%sview-%d-field-%s.php', $slug_dir, $this->view->ID, $this->field->inputType );
+				$specifics []= sprintf( '%sview-%d-field-%s-%s.php', $slug_dir, $view_id, $field_type, $slug_name );
+				$inputType && $specifics []= sprintf( '%sview-%d-field-%s-%s.php', $slug_dir, $view_id, $inputType, $slug_name );
+				$specifics []= sprintf( '%sview-%d-field-%s.php', $slug_dir, $view_id, $field_type );
+				$inputType && $specifics []= sprintf( '%sview-%d-field-%s.php', $slug_dir, $view_id, $inputType );
 
-				$specifics []= sprintf( '%sfield-%s-%s.php', $slug_dir, $this->field->type, $slug_name );
-				$this->field->inputType && $specifics []= sprintf( '%sfield-%s-%s.php', $slug_dir, $this->field->inputType, $slug_name );
-				$specifics []= sprintf( '%sfield-%s.php', $slug_dir, $this->field->type );
-				$this->field->inputType && $specifics []= sprintf( '%sfield-%s.php', $slug_dir, $this->field->inputType );
+				$specifics []= sprintf( '%sfield-%s-%s.php', $slug_dir, $field_type, $slug_name );
+				$inputType && $specifics []= sprintf( '%sfield-%s-%s.php', $slug_dir, $inputType, $slug_name );
+				$specifics []= sprintf( '%sfield-%s.php', $slug_dir, $field_type );
+				$inputType && $specifics []= sprintf( '%sfield-%s.php', $slug_dir, $inputType );
 			}
 		}
 
 		if ( $this->view ) {
 			/** Generic field templates */
-			$specifics []= sprintf( '%sview-%d-field-%s.php', $slug_dir, $this->view->ID, $slug_name );
+			$specifics []= sprintf( '%sview-%d-field-%s.php', $slug_dir, $view_id, $slug_name );
 			$specifics []= sprintf( '%sform-%d-field-%s.php', $slug_dir, $this->view->form->ID, $slug_name );
 
-			$specifics []= sprintf( '%sview-%d-field.php', $slug_dir, $this->view->ID );
+			$specifics []= sprintf( '%sview-%d-field.php', $slug_dir, $view_id );
 			$specifics []= sprintf( '%sform-%d-field.php', $slug_dir, $this->view->form->ID );
 		}
 

--- a/future/includes/class-gv-template-view-table.php
+++ b/future/includes/class-gv-template-view-table.php
@@ -17,6 +17,84 @@ class View_Table_Template extends View_Template {
 	 */
 	public static $slug = 'table';
 
+
+	/**
+     * Constructor. Add filters to modify output.
+     *
+	 * @since 2.0.4
+	 *
+	 * @param View $view
+	 * @param Entry_Collection $entries
+	 * @param Request $request
+	 */
+	public function __construct( View $view, Entry_Collection $entries, Request $request ) {
+
+	    add_filter( 'gravityview/template/field/label', array( $this, 'add_columns_sort_links' ), 100, 2 );
+
+		parent::__construct( $view, $entries, $request );
+	}
+
+	/**
+	 * @since 2.0.4
+	 */
+	public function __destruct() {
+
+		remove_filter( 'gravityview/template/field/label', array( $this, 'add_columns_sort_links' ), 100 );
+
+		parent::__destruct();
+	}
+
+	/**
+     * Add sorting links to HTML columns that support sorting
+     *
+     * @since 2.0.4
+     *
+	 * @param string $column_label Label for the table column
+	 * @param \GV\Template_Context $context
+	 *
+	 * @return string
+	 */
+	public function add_columns_sort_links( $column_label, $context = null ) {
+
+		$sort_columns = $context->view->settings->get( 'sort_columns' );
+
+		if ( empty( $sort_columns ) ) {
+            return $column_label;
+		}
+
+		if ( ! \GravityView_frontend::getInstance()->is_field_sortable( $context->field->ID, $context->view->form->form ) ) {
+			return $column_label;
+		}
+
+		$sorting = \GravityView_View::getInstance()->getSorting();
+
+		$class = 'gv-sort';
+
+		$sort_field_id = \GravityView_frontend::_override_sorting_id_by_field_type( $context->field->ID, $context->view->form->ID );
+
+		$sort_args = array(
+			'sort' => $context->field->ID,
+			'dir' => 'asc',
+		);
+
+		if ( ! empty( $sorting['key'] ) && (string) $sort_field_id === (string) $sorting['key'] ) {
+			//toggle sorting direction.
+			if ( 'asc' === $sorting['direction'] ) {
+				$sort_args['dir'] = 'desc';
+				$class .= ' gv-icon-sort-desc';
+			} else {
+				$sort_args['dir'] = 'asc';
+				$class .= ' gv-icon-sort-asc';
+			}
+		} else {
+			$class .= ' gv-icon-caret-up-down';
+		}
+
+		$url = add_query_arg( $sort_args, remove_query_arg( array('pagenum') ) );
+
+		return '<a href="'. esc_url_raw( $url ) .'" class="'. $class .'" ></a>&nbsp;'. $column_label;
+	}
+
 	/**
 	 * Output the table column names.
 	 *
@@ -184,6 +262,7 @@ class View_Table_Template extends View_Template {
 			'hide_empty' => false,
 			'zone_id' => 'directory_table-columns',
 			'markup' => '<td id="{{ field_id }}" class="{{ class }}">{{ value }}</td>',
+            'form' => $form,
 		);
 
 		/** Output. */
@@ -211,7 +290,7 @@ class View_Table_Template extends View_Template {
 		* @action `gravityview_table_body_before` Inside the `tbody`, before any rows are rendered. Can be used to insert additional rows.
 		* @deprecated Use `gravityview/template/table/body/before`
 		* @since 1.0.7
-		* @param GravityView_View $gravityview_view Current GravityView_View object.
+		* @param \GravityView_View $gravityview_view Current GravityView_View object.
 		*/
 		do_action( 'gravityview_table_body_before', \GravityView_View::getInstance() /** ugh! */ );
 	}
@@ -237,7 +316,7 @@ class View_Table_Template extends View_Template {
 		* @action `gravityview_table_body_after` Inside the `tbody`, after any rows are rendered. Can be used to insert additional rows.
 		* @deprecated Use `gravityview/template/table/body/after`
 		* @since 1.0.7
-		* @param GravityView_View $gravityview_view Current GravityView_View object.
+		* @param \GravityView_View $gravityview_view Current GravityView_View object.
 		*/
 		do_action( 'gravityview_table_body_after', \GravityView_View::getInstance() /** ugh! */ );
 	}
@@ -263,7 +342,7 @@ class View_Table_Template extends View_Template {
 		 * @action `gravityview_table_tr_before` Before the `tr` while rendering each entry in the loop. Can be used to insert additional table rows.
 		 * @since 1.0.7
 		 * @deprecated USe `gravityview/template/table/tr/before`
-		 * @param GravityView_View $gravityview_view Current GraivtyView_View object.
+		 * @param \GravityView_View $gravityview_view Current GraivtyView_View object.
 		 */
 		do_action( 'gravityview_table_tr_before', \GravityView_View::getInstance() /** ugh! */ );
 	}
@@ -289,7 +368,7 @@ class View_Table_Template extends View_Template {
 		 * @action `gravityview_table_tr_after` Inside the `tr` while rendering each entry in the loop. Can be used to insert additional table cells.
 		 * @since 1.0.7
 		 * @deprecated USe `gravityview/template/table/tr/after`
-		 * @param GravityView_View $gravityview_view Current GraivtyView_View object.
+		 * @param \GravityView_View $gravityview_view Current GravityView_View object.
 		 */
 		do_action( 'gravityview_table_tr_after', \GravityView_View::getInstance() /** ugh! */ );
 	}
@@ -310,7 +389,7 @@ class View_Table_Template extends View_Template {
 		 * @filter `gravityview_entry_class` Modify the class applied to the entry row.
 		 * @param string $class Existing class.
 		 * @param array $entry Current entry being displayed
-		 * @param GravityView_View $this Current GravityView_View object
+		 * @param \GravityView_View $this Current GravityView_View object
 		 * @deprecated Use `gravityview/template/table/entry/class`
 		 * @return string The modified class.
 		 */

--- a/future/includes/class-gv-view.php
+++ b/future/includes/class-gv-view.php
@@ -605,6 +605,7 @@ class View implements \ArrayAccess {
 			 * @todo: Stop using _frontend and use something like $request->get_search_criteria() instead
 			 */
 			$parameters = \GravityView_frontend::get_view_entries_parameters( $this->settings->as_atts(), $this->form->ID );
+			$parameters = \GVCommon::calculate_get_entries_criteria( $parameters, $this->form->ID );
 
 			if ( $request instanceof REST\Request ) {
 				$atts = $this->settings->as_atts();

--- a/future/includes/class-gv-view.php
+++ b/future/includes/class-gv-view.php
@@ -626,7 +626,7 @@ class View implements \ArrayAccess {
 				$query = new \GF_Query( $this->form->ID, $parameters['search_criteria'], $parameters['sorting'] );
 
 				$query->limit( $parameters['paging']['page_size'] )
-					->page( $page );
+					->offset( ( ( $page - 1 ) * $parameters['paging']['page_size'] ) + $this->settings->get( 'offset' ) );
 
 				/**
 				 * Any joins?

--- a/future/includes/class-gv-view.php
+++ b/future/includes/class-gv-view.php
@@ -605,6 +605,7 @@ class View implements \ArrayAccess {
 			 * @todo: Stop using _frontend and use something like $request->get_search_criteria() instead
 			 */
 			$parameters = \GravityView_frontend::get_view_entries_parameters( $this->settings->as_atts(), $this->form->ID );
+			$parameters['context_view_id'] = $this->ID;
 			$parameters = \GVCommon::calculate_get_entries_criteria( $parameters, $this->form->ID );
 
 			if ( $request instanceof REST\Request ) {

--- a/future/includes/class-gv-view.php
+++ b/future/includes/class-gv-view.php
@@ -669,8 +669,8 @@ class View implements \ArrayAccess {
 					->offset( $this->settings->get( 'offset' ) )
 					->limit( $parameters['paging']['page_size'] )
 					->page( $page );
-
-				if ( ! empty( $parameters['sorting'] ) ) {
+				
+				if ( ! empty( $parameters['sorting'] ) && ! empty( $parameters['sorting']['key'] ) ) {
 					$field = new \GV\Field();
 					$field->ID = $parameters['sorting']['key'];
 					$direction = strtolower( $parameters['sorting']['direction'] ) == 'asc' ? \GV\Entry_Sort::ASC : \GV\Entry_Sort::DESC;

--- a/future/includes/class-gv-view.php
+++ b/future/includes/class-gv-view.php
@@ -618,7 +618,7 @@ class View implements \ArrayAccess {
 			$page = Utils::get( $parameters['paging'], 'current_page' ) ?
 				: ( ( ( $parameters['paging']['offset'] - $this->settings->get( 'offset' ) ) / $parameters['paging']['page_size'] ) + 1 );
 
-			if ( gravityview()->plugin->supports( Plugin::FEATURE_JOINS ) ) {
+			if ( gravityview()->plugin->supports( Plugin::FEATURE_GFQUERY ) ) {
 				/**
 				 * New \GF_Query stuff :)
 				 */
@@ -630,7 +630,7 @@ class View implements \ArrayAccess {
 				/**
 				 * Any joins?
 				 */
-				if ( count( $this->joins ) ) {
+				if ( Plugin::FEATURE_JOINS && count( $this->joins ) ) {
 					foreach ( $this->joins as $join ) {
 						$query = $join->as_query_join( $query );
 					}

--- a/gravityview.php
+++ b/gravityview.php
@@ -3,7 +3,7 @@
  * Plugin Name:       	GravityView
  * Plugin URI:        	https://gravityview.co
  * Description:       	The best, easiest way to display Gravity Forms entries on your website.
- * Version:          	2.0.3
+ * Version:          	2.0.4
  * Author:            	GravityView
  * Author URI:        	https://gravityview.co
  * Text Domain:       	gravityview
@@ -22,7 +22,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 /**
  * The plugin version.
  */
-define( 'GV_PLUGIN_VERSION', '2.0.3' );
+define( 'GV_PLUGIN_VERSION', '2.0.4' );
 
 /**
  * Full path to the GravityView file

--- a/gravityview.php
+++ b/gravityview.php
@@ -3,7 +3,7 @@
  * Plugin Name:       	GravityView
  * Plugin URI:        	https://gravityview.co
  * Description:       	The best, easiest way to display Gravity Forms entries on your website.
- * Version:          	2.0.2
+ * Version:          	2.0.3
  * Author:            	GravityView
  * Author URI:        	https://gravityview.co
  * Text Domain:       	gravityview
@@ -22,7 +22,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 /**
  * The plugin version.
  */
-define( 'GV_PLUGIN_VERSION', '2.0.2' );
+define( 'GV_PLUGIN_VERSION', '2.0.3' );
 
 /**
  * Full path to the GravityView file

--- a/gravityview.php
+++ b/gravityview.php
@@ -67,7 +67,7 @@ define( 'GV_FUTURE_MIN_PHP_VERSION', '5.4' );
  * GravityView will soon require at least this version of Gravity Forms to function properly.
  * @since 1.19.4
  */
-define( 'GV_FUTURE_MIN_GF_VERSION', '2.2.5.22' );
+define( 'GV_FUTURE_MIN_GF_VERSION', '2.3.0' );
 
 /**
  * The future is here and now.

--- a/includes/class-admin-welcome.php
+++ b/includes/class-admin-welcome.php
@@ -311,6 +311,7 @@ class GravityView_Welcome {
                     <li>Fixed: Slow front-end performance, affecting all layout types</li>
                     <li>Fixed: Search not performing properly</li>
                     <li>Fixed: "Enable sorting by column" option for Table layouts</li>
+                    <li>GravityView will require Gravity Forms 2.3 in the future; please make sure you&rsquo;re using the latest version of Gravity Forms!</li>
                 </ul>
 
                 <p><strong>Developer Updates</strong></p>

--- a/includes/class-admin-welcome.php
+++ b/includes/class-admin-welcome.php
@@ -305,6 +305,23 @@ class GravityView_Welcome {
                     </ul>
                 </div>
 
+                <h3>2.0.4 on May 12, 2018</h3>
+
+                <ul>
+                    <li>Fixed: Slow front-end performance, affecting all layout types</li>
+                    <li>Fixed: Search not performing properly</li>
+                    <li>Fixed: "Enable sorting by column" option for Table layouts</li>
+                </ul>
+
+                <p><strong>Developer Updates</strong></p>
+
+                <ul>
+                    <li>Fixed: <code>GravityView_frontend::get_view_entries()</code> search generation</li>
+                    <li>Fixed: <code>gravityview_get_template_settings()</code> not returning settings</li>
+                    <li>Tweak: Cache View and Field magic getters into variables for less overhead.</li>
+                </ul>
+
+
                 <h3>2.0.3 on May 10, 2018</h3>
 
                 <ul>

--- a/includes/class-common.php
+++ b/includes/class-common.php
@@ -1179,8 +1179,7 @@ class GVCommon {
 
 		$settings = get_post_meta( $post_id, '_gravityview_template_settings', true );
 
-		if ( class_exists( 'GravityView_View_Data' ) ) {
-
+		if ( class_exists( '\GV\View_Settings' ) ) {
 
 			return wp_parse_args( (array)$settings, \GV\View_Settings::defaults() );
 

--- a/includes/class-frontend-views.php
+++ b/includes/class-frontend-views.php
@@ -1094,13 +1094,14 @@ class GravityView_frontend {
 	 *
 	 * @todo Filter from GravityView_Field
 	 * @since 1.7.4
+	 * @internal Hi developer! Although this is public, don't call this method; we're going to replace it.
 	 *
 	 * @param int|string $sort_field_id Field used for sorting (`id` or `1.2`)
 	 * @param int $form_id GF Form ID
 	 *
 	 * @return string Possibly modified sorting ID
 	 */
-	private static function _override_sorting_id_by_field_type( $sort_field_id, $form_id ) {
+	public static function _override_sorting_id_by_field_type( $sort_field_id, $form_id ) {
 
 		$form = gravityview_get_form( $form_id );
 

--- a/languages/gravityview.pot
+++ b/languages/gravityview.pot
@@ -562,12 +562,12 @@ msgid "Sort by field"
 msgstr ""
 
 #: future/includes/class-gv-settings-view.php:138
-#: includes/class-common.php:1310
+#: includes/class-common.php:1309
 msgid "Default"
 msgstr ""
 
 #: future/includes/class-gv-settings-view.php:139
-#: includes/class-common.php:1353
+#: includes/class-common.php:1352
 #: includes/fields/class-gravityview-field-date-created.php:27
 msgid "Date Created"
 msgstr ""
@@ -1657,7 +1657,7 @@ msgstr ""
 msgid "%s ago"
 msgstr ""
 
-#: includes/class-common.php:1463
+#: includes/class-common.php:1462
 msgid "Email hidden; Javascript is required."
 msgstr ""
 
@@ -3345,12 +3345,12 @@ msgctxt "Debugging output data is empty."
 msgid "Empty"
 msgstr ""
 
-#: includes/class-frontend-views.php:1297
+#: includes/class-frontend-views.php:1298
 msgctxt "Clear all data from the form"
 msgid "Clear"
 msgstr ""
 
-#: includes/class-frontend-views.php:1298
+#: includes/class-frontend-views.php:1299
 msgctxt "Reset the search form to the state that existed on page load"
 msgid "Reset"
 msgstr ""

--- a/package.json
+++ b/package.json
@@ -14,10 +14,11 @@
     "grunt-potomo": "^3.1.0",
     "grunt-wp-i18n": "^0.5.1",
     "grunt-wp-readme-to-markdown": "^0.8.0",
-    "load-grunt-tasks": "^3.5.0"
+    "load-grunt-tasks": "^3.5.2"
   },
   "repository": {
     "type": "git",
     "url": "https://github.com/gravityview/GravityView.git"
-  }
+  },
+  "dependencies": {}
 }

--- a/readme.txt
+++ b/readme.txt
@@ -26,6 +26,7 @@ Beautifully display your Gravity Forms entries. Learn more on [gravityview.co](h
 * Fixed: Slow front-end performance, affecting all layout types
 * Fixed: Search not performing properly
 * Fixed: "Enable sorting by column" option for Table layouts
+* GravityView will require Gravity Forms 2.3 in the future; please make sure you're using the latest version of Gravity Forms!
 
 __Developer Updates__
 

--- a/readme.txt
+++ b/readme.txt
@@ -21,7 +21,17 @@ Beautifully display your Gravity Forms entries. Learn more on [gravityview.co](h
 
 == Changelog ==
 
+= 2.0.4 on May 12, 2018 =
+
+* Fixed: Slow front-end performance, affecting all layout types
+* Fixed: Search not performing properly
 * Fixed: "Enable sorting by column" option for Table layouts
+
+__Developer Updates__
+
+* Fixed: `GravityView_frontend::get_view_entries()` search generation
+* Fixed: `gravityview_get_template_settings()` not returning settings
+* Tweak: Cache View and Field magic getters into variables for less overhead.
 
 = 2.0.3 on May 10, 2018 =
 

--- a/readme.txt
+++ b/readme.txt
@@ -21,6 +21,8 @@ Beautifully display your Gravity Forms entries. Learn more on [gravityview.co](h
 
 == Changelog ==
 
+* Fixed: "Enable sorting by column" option for Table layouts
+
 = 2.0.3 on May 10, 2018 =
 
 * Fixed: Compatibility with `[gravitypdf]` shortcode

--- a/tests/unit-tests/GravityView_Future_Test.php
+++ b/tests/unit-tests/GravityView_Future_Test.php
@@ -4337,6 +4337,9 @@ class GVFuture_Test extends GV_UnitTestCase {
 
 		$view->settings->update( array( 'page_size' => 1, 'offset' => 1 ) );
 
+		$view->settings->set( 'sort_field', 'id' );
+		$view->settings->set( 'sort_direction', 'desc' );
+
 		$entries = GravityView_frontend::get_view_entries( $view->settings->as_atts(), $form->ID );
 		$this->assertEquals( 1, $entries['count'] );
 		$this->assertEquals( array( 'offset' => 0, 'page_size' => 1 ), $entries['paging'] );

--- a/tests/unit-tests/GravityView_Future_Test.php
+++ b/tests/unit-tests/GravityView_Future_Test.php
@@ -2016,6 +2016,23 @@ class GVFuture_Test extends GV_UnitTestCase {
 		$this->assertContains( 'text in a textarea', $future );
 		$this->assertContains( 'Let&#039;s go back!', $future );
 		$this->assertNotContains( 'Country', $future );
+
+
+		// Check sorting links
+		$view->settings->set( 'sort_columns', '1' );
+
+		$legacy = \GravityView_frontend::getInstance()->insert_view_in_content( '' );
+		$future = $renderer->render( $entry, $view );
+		$this->assertEquals( $legacy, $future );
+		$this->assertContains( 'class="gv-sort', $future );
+
+		// Check sorting links
+		$view->settings->set( 'sort_columns', '0' );
+
+		$legacy = \GravityView_frontend::getInstance()->insert_view_in_content( '' );
+		$future = $renderer->render( $entry, $view );
+		$this->assertEquals( $legacy, $future );
+		$this->assertNotContains( 'class="gv-sort', $future );
 	}
 
 	public function test_entry_renderer_table_hide_empty() {


### PR DESCRIPTION
* Fixed: Slow front-end performance, affecting all layout types
* Fixed: Search not performing properly
* Fixed: "Enable sorting by column" option for Table layouts
* GravityView will require Gravity Forms 2.3 in the future; please make sure you're using the latest version of Gravity Forms!

__Developer Updates__

* Fixed: `GravityView_frontend::get_view_entries()` search generation
* Fixed: `gravityview_get_template_settings()` not returning settings
* Tweak: Cache View and Field magic getters into variables for less overhead.