### PR TITLE
Another way to do the fix is to push the legacy state

### DIFF
--- a/future/_mocks.php
+++ b/future/_mocks.php
@@ -551,8 +551,8 @@ final class Legacy_Context {
 
 					self::thaw( array(
 						'\GravityView_View::atts' => $value->settings->as_atts(),
-						'\GravityView_View::view_id' => $value->ID,
-						'\GravityView_View::back_link_label' => $value->settings->get( 'back_link_label', null ),
+						'\GravityView_View::view_id' => $value->ID, /** @see \GravityView_View::$view_id */
+						'\GravityView_View::back_link_label' => $value->settings->get( 'back_link_label', null ), /** @see \GravityView_View::$back_link_label */
 						'\GravityView_View::form' => $value->form ? $value->form->form : null,
 						'\GravityView_View::form_id' => $value->form ? $value->form->ID : null,
 

--- a/future/includes/class-gv-entry.php
+++ b/future/includes/class-gv-entry.php
@@ -98,7 +98,7 @@ abstract class Entry {
 	 * @api
 	 * @since 2.0
 	 *
-	 * @param \GV\View|null $view The View context.
+	 * @param \GV\View $view The View context.
 	 * @param \GV\Request $request The Request (current if null).
 	 * @param boolean $track_directory Keep the housing directory arguments intact (used for breadcrumbs, for example). Default: true.
 	 *
@@ -113,8 +113,6 @@ abstract class Entry {
 
 		$args = array();
 
-		$view_id = is_null ( $view ) ? null : $view->ID;
-
 		$permalink = null;
 
 		/** This is not a regular view. */
@@ -123,13 +121,13 @@ abstract class Entry {
 			/** Must be an embed of some sort. */
 			if ( is_object( $post ) && is_numeric( $post->ID ) ) {
 				$permalink = get_permalink( $post->ID );
-				$args['gvid'] = $view_id;
+				$args['gvid'] = $view->ID;
 			}
 		}
 		
 		/** Fallback to regular view base. */
 		if ( is_null( $permalink ) ) {
-			$permalink = get_permalink( $view_id );
+			$permalink = get_permalink( $view->ID );
 		}
 
 		/**
@@ -138,7 +136,7 @@ abstract class Entry {
 		 * @param string $link URL to the View's "directory" context (Multiple Entries screen)
 		 * @param int $post_id ID of the post to link to. If the View is embedded, it is the post or page ID
 		 */
-		$permalink = apply_filters( 'gravityview_directory_link', $permalink, $request->is_view() ? $view_id : ( $post ? $post->ID : null ) );
+		$permalink = apply_filters( 'gravityview_directory_link', $permalink, $request->is_view() ? $view->ID : ( $post ? $post->ID : null ) );
 
 		$entry_endpoint_name = \GV\Entry::get_endpoint_name();
 		$entry_slug = \GravityView_API::get_entry_slug( $this->ID, $this->as_entry() );

--- a/future/includes/class-gv-template-legacy-override.php
+++ b/future/includes/class-gv-template-legacy-override.php
@@ -186,7 +186,7 @@ class Legacy_Override_Template extends \Gamajo_Template_Loader {
 
 			\GravityView_View::getInstance()->_include( $this->get_template_part( $slug, 'single' ) );
 
-			Mocks\Legacy_Context::pop();
+			\GV\Mocks\Legacy_Context::pop();
 
 		/**
 		 * Directory view.
@@ -221,7 +221,7 @@ class Legacy_Override_Template extends \Gamajo_Template_Loader {
 
 				\GravityView_View::getInstance()->_include( $this->get_template_part( $slug, $part ) );
 
-				Mocks\Legacy_Context::pop();
+				\GV\Mocks\Legacy_Context::pop();
 			}
 		}
 

--- a/includes/class-template.php
+++ b/includes/class-template.php
@@ -683,11 +683,22 @@ class GravityView_View extends Gamajo_Template_Loader {
 		}
 
 		$field_output = '';
+
+        $view = \GV\View::by_id( $this->view_id );
+
+		\GV\Mocks\Legacy_Context::push( array_merge( array(
+			'view' => $view,
+			'fields' => \GV\Field_Collection::from_configuration( $fields ),
+			'in_the_loop' => true,
+            'entry' => \GV\GF_Entry::from_entry( $final_atts['entry'] ),
+		) ) );
+
 		foreach ( $fields as $field ) {
 			$final_atts['field'] = $field;
-
 			$field_output .= gravityview_field_output( $final_atts );
 		}
+
+		\GV\Mocks\Legacy_Context::pop();
 
 		/**
 		 * If a zone has no field output, choose whether to show wrapper


### PR DESCRIPTION
Reverts 43fa421659dcb61fdc2612d9836b88200d87e626 in favor of pushing legacy state. Messier, but also more "pure", perhaps?

Which is better, @soulseekah?

Fixes #1048 