### PR TITLE
Namespace Gamajo template loader

### DIFF
--- a/future/includes/class-gv-collection-view.php
+++ b/future/includes/class-gv-collection-view.php
@@ -73,7 +73,7 @@ class View_Collection extends Collection {
 	 *
 	 * @api
 	 * @since 2.0
-	 * @return \GV\View_Collection A \GV\View_Collection instance contanining the views inside the supplied \WP_Post.
+	 * @return \GV\View_Collection A \GV\View_Collection instance containing the views inside the supplied \WP_Post.
 	 */
 	public static function from_post( \WP_Post $post ) {
 		$views = new self();

--- a/future/includes/class-gv-template-entry.php
+++ b/future/includes/class-gv-template-entry.php
@@ -11,7 +11,7 @@ if ( ! defined( 'GRAVITYVIEW_DIR' ) ) {
  *
  * @see https://github.com/GaryJones/Gamajo-Template-Loader
  */
-if ( ! class_exists( 'Gamajo_Template_Loader' ) ) {
+if ( ! class_exists( '\GV\Gamajo_Template_Loader' ) ) {
 	require gravityview()->plugin->dir( 'future/lib/class-gamajo-template-loader.php' );
 }
 

--- a/future/includes/class-gv-template-field.php
+++ b/future/includes/class-gv-template-field.php
@@ -11,7 +11,7 @@ if ( ! defined( 'GRAVITYVIEW_DIR' ) ) {
  *
  * @see https://github.com/GaryJones/Gamajo-Template-Loader
  */
-if ( ! class_exists( 'Gamajo_Template_Loader' ) ) {
+if ( ! class_exists( '\GV\Gamajo_Template_Loader' ) ) {
 	require gravityview()->plugin->dir( 'future/lib/class-gamajo-template-loader.php' );
 }
 

--- a/future/includes/class-gv-template-legacy-override.php
+++ b/future/includes/class-gv-template-legacy-override.php
@@ -11,7 +11,7 @@ if ( ! defined( 'GRAVITYVIEW_DIR' ) ) {
  *
  * @see https://github.com/GaryJones/Gamajo-Template-Loader
  */
-if ( ! class_exists( '\Gamajo_Template_Loader' ) ) {
+if ( ! class_exists( '\GV\Gamajo_Template_Loader' ) ) {
 	require gravityview()->plugin->dir( 'future/lib/class-gamajo-template-loader.php' );
 }
 
@@ -20,7 +20,7 @@ if ( ! class_exists( '\Gamajo_Template_Loader' ) ) {
  *
  * Makes sure they work by setting up context, etc.
  */
-class Legacy_Override_Template extends \Gamajo_Template_Loader {
+class Legacy_Override_Template extends \GV\Gamajo_Template_Loader {
 	/**
 	 * Prefix for filter names.
 	 * @var string

--- a/future/includes/class-gv-template-view.php
+++ b/future/includes/class-gv-template-view.php
@@ -11,7 +11,7 @@ if ( ! defined( 'GRAVITYVIEW_DIR' ) ) {
  *
  * @see https://github.com/GaryJones/Gamajo-Template-Loader
  */
-if ( ! class_exists( 'Gamajo_Template_Loader' ) ) {
+if ( ! class_exists( '\GV\Gamajo_Template_Loader' ) ) {
 	require gravityview()->plugin->dir( 'future/lib/class-gamajo-template-loader.php' );
 }
 

--- a/future/includes/class-gv-template.php
+++ b/future/includes/class-gv-template.php
@@ -11,7 +11,7 @@ if ( ! defined( 'GRAVITYVIEW_DIR' ) ) {
  *
  * @see https://github.com/GaryJones/Gamajo-Template-Loader
  */
-if ( ! class_exists( '\Gamajo_Template_Loader' ) ) {
+if ( ! class_exists( '\GV\Gamajo_Template_Loader' ) ) {
 	require gravityview()->plugin->dir( 'future/lib/class-gamajo-template-loader.php' );
 }
 
@@ -21,7 +21,7 @@ if ( ! class_exists( '\Gamajo_Template_Loader' ) ) {
  * Stores information on where a template to render an object is,
  *  and other metadata.
  */
-abstract class Template extends \Gamajo_Template_Loader {
+abstract class Template extends \GV\Gamajo_Template_Loader {
 	
 	/**
 	 * @var array The template data stack.

--- a/future/lib/class-gamajo-template-loader.php
+++ b/future/lib/class-gamajo-template-loader.php
@@ -10,7 +10,9 @@
  * @version   1.3.0
  */
 
-if ( ! class_exists( 'Gamajo_Template_Loader' ) ) {
+namespace GV;
+
+if ( ! class_exists( '\GV\Gamajo_Template_Loader' ) ) {
 
 	/**
 	 * Template loader.

--- a/includes/class-template.php
+++ b/includes/class-template.php
@@ -16,11 +16,11 @@ if ( ! defined( 'ABSPATH' ) ) {
 	die;
 }
 
-if( ! class_exists( 'Gamajo_Template_Loader' ) ) {
+if( ! class_exists( '\GV\Gamajo_Template_Loader' ) ) {
 	require( GRAVITYVIEW_DIR . 'includes/lib/class-gamajo-template-loader.php' );
 }
 
-class GravityView_View extends Gamajo_Template_Loader {
+class GravityView_View extends \GV\Gamajo_Template_Loader {
 
 	/**
 	 * Prefix for filter names.


### PR DESCRIPTION
I forgot back-compat with older versions are why we hadn't been using `set_template_data()`…

That kind of thing is why we need to load our own version that we can rely on.

@soulseekah Can you review this? 

Fixes #1072 