### PR TITLE
If ?post_id=123 is passed to REST request, set parent post/page

### DIFF
--- a/future/includes/rest/class-gv-rest-route.php
+++ b/future/includes/rest/class-gv-rest-route.php
@@ -56,6 +56,10 @@ abstract class Route extends \WP_REST_Controller {
 					'limit' => array(
 						'default' => 10,
 						'sanitize_callback' => 'absint'
+					),
+					'post_id' => array(
+						'default' => null,
+						'sanitize_callback' => 'absint'
 					)
 				)
 			),
@@ -110,6 +114,10 @@ abstract class Route extends \WP_REST_Controller {
 					),
 					'limit' => array(
 						'default' => 10,
+						'sanitize_callback' => 'absint'
+					),
+					'post_id' => array(
+						'default' => null,
 						'sanitize_callback' => 'absint'
 					)
 				)

--- a/future/includes/rest/class-gv-rest-views-route.php
+++ b/future/includes/rest/class-gv-rest-views-route.php
@@ -159,6 +159,22 @@ class Views_Route extends Route {
 		$view_id = intval( $url['id'] );
 		$format  = \GV\Utils::get( $url, 'format', 'json' );
 
+		if( $post_id = $request->get_param('post_id') ) {
+			global $post;
+
+			$post = get_post( $post_id );
+
+			if ( ! $post || is_wp_error( $post ) ) {
+				return new \WP_Error( 'gravityview-post-not-found', sprintf( 'A post with ID #%d was not found.', $post_id ) );
+			}
+
+			$collection = \GV\View_Collection::from_post( $post );
+
+			if ( ! $collection->contains( $view_id ) ) {
+				return new \WP_Error( 'gravityview-post-not-contains', sprintf( 'The post with ID #%d does not contain a View with ID #%d', $post_id, $view_id ) );
+			}
+		}
+
 		$view = \GV\View::by_id( $view_id );
 
 		if ( $format == 'html' ) {

--- a/tests/unit-tests/GravityView_REST_Test.php
+++ b/tests/unit-tests/GravityView_REST_Test.php
@@ -36,7 +36,7 @@ class GravityView_REST_Test extends GV_RESTUnitTestCase {
 		$this->assertEquals( 200, $response->status );
 		$data     = $response->get_data();
 
-		$this->assertEquals( array( 'page', 'limit' ), array_keys( $data['endpoints'][0]['args'] ) );
+		$this->assertEquals( array( 'page', 'limit', 'post_id' ), array_keys( $data['endpoints'][0]['args'] ) );
 
 		$form = $this->factory->form->create_and_get();
 		$entry = $this->factory->entry->import_and_get( 'simple_entry.json', array(


### PR DESCRIPTION
The REST request didn't have a good way to handle when a View is embedded in a post or page. This affected the output of URLs, for example.

This allows defining the parent post/page via URL string.

Is this a decent way to do this, @soulseekah?