### PR TITLE
Hotfix revert: images were turning into partial links

### DIFF
--- a/gravityview.php
+++ b/gravityview.php
@@ -3,7 +3,7 @@
  * Plugin Name:       	GravityView
  * Plugin URI:        	https://gravityview.co
  * Description:       	The best, easiest way to display Gravity Forms entries on your website.
- * Version:          	2.1.0.1
+ * Version:          	2.1.0.2
  * Author:            	GravityView
  * Author URI:        	https://gravityview.co
  * Text Domain:       	gravityview
@@ -22,7 +22,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 /**
  * The plugin version.
  */
-define( 'GV_PLUGIN_VERSION', '2.1.0.1' );
+define( 'GV_PLUGIN_VERSION', '2.1.0.2' );
 
 /**
  * Full path to the GravityView file

--- a/includes/class-admin-welcome.php
+++ b/includes/class-admin-welcome.php
@@ -311,6 +311,12 @@ class GravityView_Welcome {
                     <li>REST API: Allow setting parent post or page with the REST API request using <code>post_id={id}</code> (<a href="https://docs.gravityview.co/article/468-rest-api">learn more</a>)</li>
                     <li>REST API: Added <code>X-Item-Total</code> header and meta to REST API response</li>
                 </ul>
+                
+                <h3>2.1.0.2 on September 28, 2018</h3>
+
+                <ul>
+                    <li>Fixed: Images showing as links for File Upload fields</li>
+                </ul>
 
                 <h3>2.1.0.1 on September 27, 2018</h3>
 

--- a/includes/fields/class-gravityview-field-fileupload.php
+++ b/includes/fields/class-gravityview-field-fileupload.php
@@ -152,8 +152,6 @@ class GravityView_Field_FileUpload extends GravityView_Field {
 			// This is from Gravity Forms's code
 			$file_path = esc_attr( str_replace( " ", "%20", $file_path ) );
 
-			$file_path = $field->get_download_url( $file_path );
-
 			/**
 			 * @filter `gravityview/fields/fileupload/file_path` Modify the file path before generating a link to it
 			 * @since 1.22.3

--- a/readme.txt
+++ b/readme.txt
@@ -21,6 +21,10 @@ Beautifully display your Gravity Forms entries. Learn more on [gravityview.co](h
 
 == Changelog ==
 
+= 2.1.0.2 on September 28, 2018 =
+
+* Fixed: Images showing as links for File Upload fields
+
 = 2.1.0.1 on September 27, 2018 =
 
 * Fixed: Responsive table layout labels showing sorting icon HTML


### PR DESCRIPTION
Revert 9743f17ed50ec7b61f02a2e7805a44980eb97f1d

We can add this back in after making sure that it's working properly.

The reason we added it is so that it uses the GF-generated download URL with the hash. It's not a full URL, so I think pathinfo() isn't generating the extension properly, so it's not being recognized as an image.