### PR TITLE
Use $context when generating entry_link URL instead of old API

### DIFF
--- a/includes/class-api.php
+++ b/includes/class-api.php
@@ -657,7 +657,15 @@ class GravityView_API {
 
 		}
 
-		if ( class_exists( 'GravityView_View_Data' ) && GravityView_View_Data::getInstance()->has_multiple_views() ) {
+		if( $post_id ) {
+			$passed_post = get_post( $post_id );
+			$views       = \GV\View_Collection::from_post( $passed_post );
+			$has_multiple_views = $views->count() > 1;
+		} else {
+			$has_multiple_views = class_exists( 'GravityView_View_Data' ) && GravityView_View_Data::getInstance()->has_multiple_views();
+		}
+
+		if ( $has_multiple_views ) {
 			$args['gvid'] = gravityview_get_view_id();
 		}
 

--- a/templates/fields/field-entry_link-html.php
+++ b/templates/fields/field-entry_link-html.php
@@ -21,4 +21,17 @@ if ( ! empty( $field_settings['new_window'] ) ) {
 
 global $post;
 
-echo GravityView_API::entry_link_html( $entry, $output, $tag_atts, $field_settings, $post ? $post->ID : $gravityview->view->ID );
+$href = $gravityview->entry->get_permalink( $gravityview->view, $gravityview->request, $tag_atts );
+
+$link = gravityview_get_link( $href, $output, $tag_atts );
+
+/**
+ * @filter `gravityview_field_entry_link` Modify the link HTML (here for backward compatibility)
+ * @param string $link HTML output of the link
+ * @param string $href URL of the link
+ * @param array  $entry The GF entry array
+ * @param  array $field_settings Settings for the particular GV field
+ */
+$output = apply_filters( 'gravityview_field_entry_link', $link, $href, $entry, $field_settings );
+
+echo $output;


### PR DESCRIPTION
Reproduces #1190, and also fixes #1190 