### PR TITLE
Fix #1210 - Accessing edit entry on joined Views

### DIFF
--- a/future/includes/class-gv-request.php
+++ b/future/includes/class-gv-request.php
@@ -135,18 +135,26 @@ abstract class Request {
 					array_push( $multientry, $e );
 				}
 
+				// Allow Edit Entry to only edit a single entry on a multi-entry
+				$is_edit_entry = apply_filters( 'gravityview_is_edit_entry', false );
+
 				/**
 				 * Not all forms have been requested.
 				 */
-				if ( count( $needs_forms ) ) {
+				if ( count( $needs_forms ) && ! $is_edit_entry ) {
 					return false;
 				}
 
-				if ( ( count( $multientry ) - 1 ) != count( $joins ) ) {
+				if ( ( count( $multientry ) - 1 ) != count( $joins ) && ! $is_edit_entry ) {
 					return false;
 				}
 
-				$entry = Multi_Entry::from_entries( array_filter( $multientry ) );
+				if ( $is_edit_entry && 1 === count( $multientry ) ) {
+					$entry = $multientry[0];
+				} else {
+					$entry = Multi_Entry::from_entries( array_filter( $multientry ) );
+				}
+				
 			}  else {
 				/**
 				 * A regular one.

--- a/includes/extensions/edit-entry/class-edit-entry-render.php
+++ b/includes/extensions/edit-entry/class-edit-entry-render.php
@@ -213,7 +213,7 @@ class GravityView_Edit_Entry_Render {
 
 		self::$original_form = $gravityview_view->getForm();
 		$this->form = $gravityview_view->getForm();
-		$this->form_id = $gravityview_view->getFormId();
+		$this->form_id = $this->entry['form_id'];
 		$this->view_id = $gravityview_view->getViewId();
 		$this->post_id = \GV\Utils::get( $post, 'ID', null );
 

--- a/templates/fields/field-edit_link-html.php
+++ b/templates/fields/field-edit_link-html.php
@@ -6,7 +6,13 @@
  * @since 2.0
  */
 $form = $gravityview->view->form->form;
-$entry = $gravityview->entry->as_entry();
+
+if ( $gravityview->entry->is_multi() ) {
+	$entry = $gravityview->entry->from_field( $gravityview->field )->as_entry();
+} else {
+	$entry = $gravityview->entry->as_entry();
+}
+
 $field_settings = $gravityview->field->as_configuration();
 
 global $post;


### PR DESCRIPTION
This bypasses the requirement for all forms in all joins to be satisfied when `gravityview_is_edit_entry` is true.

Fixes #1210 