### PR TITLE
Tweak textdomain loading

### DIFF
--- a/future/includes/class-gv-plugin.php
+++ b/future/includes/class-gv-plugin.php
@@ -320,7 +320,7 @@ final class Plugin {
 	 * @return string The absolute path to the plugin directory.
 	 */
 	public function dir( $path = '' ) {
-		return GRAVITYVIEW_DIR . ltrim( $path, '/' );
+		return wp_normalize_path( GRAVITYVIEW_DIR . ltrim( $path, '/' ) );
 	}
 
 	/**

--- a/future/includes/class-gv-plugin.php
+++ b/future/includes/class-gv-plugin.php
@@ -311,7 +311,7 @@ final class Plugin {
 	}
 
 	/**
-	 * Retrieve an absolute path within the Gravity Forms plugin directory.
+	 * Retrieve an absolute path within the GravityView plugin directory.
 	 *
 	 * @api
 	 * @since 2.0
@@ -324,7 +324,23 @@ final class Plugin {
 	}
 
 	/**
-	 * Retrieve a URL within the Gravity Forms plugin directory.
+	 * Retrieve a relative path to the GravityView plugin directory from the WordPress plugin directory
+	 *
+	 * @api
+	 * @since 2.2.3
+	 *
+	 * @param string $path Optional. Append this extra path component.
+	 * @return string The relative path to the plugin directory from the plugin directory.
+	 */
+	public function relpath( $path = '' ) {
+
+		$dirname = trailingslashit( dirname( plugin_basename( GRAVITYVIEW_FILE ) ) );
+
+		return wp_normalize_path( $dirname . ltrim( $path, '/' ) );
+	}
+
+	/**
+	 * Retrieve a URL within the GravityView plugin directory.
 	 *
 	 * @api
 	 * @since 2.0

--- a/future/includes/class-gv-plugin.php
+++ b/future/includes/class-gv-plugin.php
@@ -237,13 +237,13 @@ final class Plugin {
 	 * @return void
 	 */
 	public function load_textdomain() {
-		$loaded = load_plugin_textdomain( 'gravityview', false, $this->dir( 'languages' ) );
 		
 		if ( ! $loaded ) {
 			$loaded = load_muplugin_textdomain( 'gravityview', '/languages/' );
 		}
 		if ( ! $loaded ) {
 			$loaded = load_theme_textdomain( 'gravityview', '/languages/' );
+		$loaded = load_plugin_textdomain( $domain, false, $this->relpath( '/languages/' ) );
 		}
 		if ( ! $loaded ) {
 

--- a/tests/unit-tests/GravityView_Future_Test.php
+++ b/tests/unit-tests/GravityView_Future_Test.php
@@ -48,11 +48,17 @@ class GVFuture_Test extends GV_UnitTestCase {
 	/**
 	 * @covers \GV\Plugin::dir()
 	 * @covers \GV\Plugin::url()
+     * @covers \GV\Plugin::relpath()
 	 */
-	public function test_plugin_dir_and_url() {
-		$this->assertEquals( GRAVITYVIEW_DIR, gravityview()->plugin->dir() );
+	public function test_plugin_dir_and_url_and_relpath() {
+	    $this->assertEquals( GRAVITYVIEW_DIR, gravityview()->plugin->dir() );
 		$this->assertStringEndsWith( '/gravityview/test/this.php', strtolower( gravityview()->plugin->dir( 'test/this.php' ) ) );
 		$this->assertStringEndsWith( '/gravityview/and/this.php', strtolower( gravityview()->plugin->dir( '/and/this.php' ) ) );
+
+		$dirname = trailingslashit( dirname( plugin_basename( GRAVITYVIEW_FILE ) ) );
+		$this->assertEquals( $dirname, gravityview()->plugin->relpath() );
+		$this->assertEquals( $dirname . 'languages/', gravityview()->plugin->relpath('/languages/') );
+		$this->assertEquals( $dirname . 'languages', gravityview()->plugin->relpath('languages') );
 
 		/** Due to how WP_PLUGIN_DIR is different in test mode, we are only able to check bits of the URL */
 		$this->assertStringStartsWith( 'http', strtolower( gravityview()->plugin->url() ) );


### PR DESCRIPTION
There were issues with the prior textdomain loading process::

- `load_plugin_textdomain()` was being passed an absolute path, so it wouldn't ever find anything
- `load_theme_textdomain()` didn't work; it would look for `/languages/fr_FR.mo`, which isn't plugin specific. Not really the correct usage.
- IIS paths weren't being fixed (backslashes)