### PR TITLE
Fix sorting

### DIFF
--- a/future/includes/class-gv-field.php
+++ b/future/includes/class-gv-field.php
@@ -187,7 +187,7 @@ class Field {
 			return $field;
 		}
 
-		/** Determine the field implementation to use, and try to use. */
+		/** @var \GV\GF_Field|\GV\Internal_Field $field_class Determine the field implementation to use, and try to use. */
 		$field_class = is_numeric( $configuration['id'] ) ? '\GV\GF_Field' : '\GV\Internal_Field';
 
 		/**

--- a/future/includes/class-gv-view.php
+++ b/future/includes/class-gv-view.php
@@ -959,7 +959,10 @@ class View implements \ArrayAccess {
 			}
 
 			if ( gravityview()->plugin->supports( Plugin::FEATURE_GFQUERY ) ) {
+
 				$query_class = $this->get_query_class();
+
+				/** @var \GF_Query $query */
 				$query = new $query_class( $this->form->ID, $parameters['search_criteria'], $parameters['sorting'] );
 
 				/**
@@ -968,18 +971,28 @@ class View implements \ArrayAccess {
 				if ( ! empty( $has_multisort ) ) {
 					$atts = $this->settings->as_atts();
 
-					if ( $this->settings->get( 'sort_columns' ) && ! empty( $_GET['sort'] ) && is_array( $_GET['sort'] ) ) {
+					$view_setting_sort_field_ids = \GV\Utils::get( $atts, 'sort_field', array() );
+					$view_setting_sort_directions = \GV\Utils::get( $atts, 'sort_direction', array() );
+
+					$has_sort_query_param = ! empty( $_GET['sort'] ) && is_array( $_GET['sort'] );
+
+					if( $has_sort_query_param ) {
+						$has_sort_query_param = array_filter( array_values( $_GET['sort'] ) );
+					}
+
+					if ( $this->settings->get( 'sort_columns' ) && $has_sort_query_param ) {
 						$sort_field_ids = array_keys( $_GET['sort'] );
 						$sort_directions = array_values( $_GET['sort'] );
 					} else {
-						$sort_field_ids = \GV\Utils::get( $atts, 'sort_field', array() );
-						$sort_directions = \GV\Utils::get( $atts, 'sort_direction', array() );
+						$sort_field_ids = $view_setting_sort_field_ids;
+						$sort_directions = $view_setting_sort_directions;
 					}
 
 					$skip_first = false;
 
 					foreach ( (array) $sort_field_ids as $key => $sort_field_id ) {
-						if ( ! $skip_first ) {
+
+						if ( ! $skip_first && ! $has_sort_query_param ) {
 							$skip_first = true; // Skip the first one, it's already in the query
 							continue;
 						}

--- a/includes/class-frontend-views.php
+++ b/includes/class-frontend-views.php
@@ -1040,7 +1040,14 @@ class GravityView_frontend {
 	 */
 	public static function updateViewSorting( $args, $form_id ) {
 		$sorting = array();
-		$sort_field_id = isset( $_GET['sort'] ) ? $_GET['sort'] : \GV\Utils::get( $args, 'sort_field' );
+
+		$has_values = isset( $_GET['sort'] );
+
+		if ( $has_values && is_array( $_GET['sort'] ) ) {
+			$has_values = array_filter( array_values( $_GET['sort'] ) );
+		}
+
+		$sort_field_id = $has_values ? $_GET['sort'] : \GV\Utils::get( $args, 'sort_field' );
 		$sort_direction = isset( $_GET['dir'] ) ? $_GET['dir'] : \GV\Utils::get( $args, 'sort_direction' );
 
 		if ( is_array( $sort_field_id ) ) {

--- a/tests/unit-tests/GravityView_Future_Test.php
+++ b/tests/unit-tests/GravityView_Future_Test.php
@@ -8238,6 +8238,83 @@ class GVFuture_Test extends GV_UnitTestCase {
 
 		$this->_reset_context();
 	}
+
+	public function test_sort_reset() {
+		$this->_reset_context();
+
+		$form = $this->factory->form->import_and_get( 'complete.json' );
+		$form = \GV\GF_Form::by_id( $form['id'] );
+
+		global $post;
+
+		$post = $this->factory->view->create_and_get( array(
+			'form_id' => $form->ID,
+			'template_id' => 'table',
+            'fields' => array(
+				'directory_table-columns' => array(
+					wp_generate_password( 4, false ) => array(
+						'id' => '4',
+						'label' => 'Email',
+					),
+				),
+			),
+		) );
+		$view = \GV\View::from_post( $post );
+
+		$this->factory->entry->create_and_get( array(
+			'form_id' => $form->ID,
+			'status' => 'active',
+			'4' => 'gennady@gravityview.co',
+		) );
+
+		$this->factory->entry->create_and_get( array(
+			'form_id' => $form->ID,
+			'status' => 'active',
+			'4' => 'vlad@gravityview.co',
+		) );
+
+		$this->factory->entry->create_and_get( array(
+			'form_id' => $form->ID,
+			'status' => 'active',
+			'4' => 'rafael@gravityview.co',
+		) );
+
+		$this->factory->entry->create_and_get( array(
+			'form_id' => $form->ID,
+			'status' => 'active',
+			'4' => 'zack@gravityview.co',
+		) );
+
+		$renderer = new \GV\View_Renderer();
+
+		gravityview()->request = new \GV\Mock_Request();
+		gravityview()->request->returns['is_view'] = $view;
+
+		$view->settings->set( 'sort_columns', '1' );
+
+		$_GET['sort'] = array( '4' => 'DESC', );
+
+		$output = $renderer->render( $view );
+
+		$this->assertContains( 'gv-icon-sort-asc', $output );
+		$this->assertContains( urlencode( 'sort[4]' ) . '"', $output );
+
+		$_GET['sort'] = array( '4' => 'ASC', );
+
+		$output = $renderer->render( $view );
+
+		$this->assertContains( 'gv-icon-sort-desc', $output );
+		$this->assertContains( urlencode( 'sort[4]' ) . '=desc', $output );
+
+		$_GET['sort'] = array( '4' => '', );
+
+		$output = $renderer->render( $view );
+
+		$this->assertContains( 'gv-icon-caret-up-down', $output );
+		$this->assertContains( urlencode( 'sort[4]' ) . '=asc', $output );
+
+		$this->_reset_context();
+	}
 }
 
 class GVFutureTest_Extension_Test_BC extends GravityView_Extension {


### PR DESCRIPTION
This issue was likely introduced by the introduction of an empty `?sort` parameter in dec13f6e249361855047487369cedd97fdf2a1ee, as well as multisort.

The main issue is that `$skip_first` was being applied too aggressively; if the URL being passed only included one sort, like `?sort[20]=asc`, it was being skipped.

When a sort is provided but it's empty, `updateViewSorting()` returns an empty array, which breaks things.

@soulseekah Can you write some tests that play with this some more?

Fixes #1323