### PR TITLE
Fix recursion conflict with Nested Forms.

### DIFF
--- a/includes/extensions/edit-entry/class-edit-entry-render.php
+++ b/includes/extensions/edit-entry/class-edit-entry-render.php
@@ -1155,7 +1155,7 @@ class GravityView_Edit_Entry_Render {
 	public function filter_modify_form_fields( $form, $ajax = false, $field_values = '' ) {
 
 		// In case we have validated the form, use it to inject the validation results into the form render
-		if( isset( $this->form_after_validation ) ) {
+		if( isset( $this->form_after_validation ) && $this->form_after_validation['id'] === $form['id'] ) {
 			$form = $this->form_after_validation;
 		} else {
 			$form['fields'] = $this->get_configured_edit_fields( $form, $this->view_id );


### PR DESCRIPTION
This PR fixes a conflict with GP Nested Forms where editing a child entry and then submitting a parent form in a GravityView Edit view resulted in an infinite loop. This PR resolves the issue by limiting the `filter_modify_form_fields()` method to only apply to the form that has been submitted rather than all forms that are passed through the `gform_pre_render` filter as Nested Forms calls this filter for each child form.