### PR TITLE
Change the CSV glue for multiple items

### DIFF
--- a/future/includes/class-gv-field.php
+++ b/future/includes/class-gv-field.php
@@ -294,7 +294,7 @@ class Field {
 	public function get_value( View $view = null, Source $source = null, Entry $entry = null, Request $request = null ) {
 		return $this->get_value_filters( null, $view, $source, $entry, $request );
 	}
-	
+
 	/**
 	 * Apply all the required filters after get_value() was called.
 	 *

--- a/readme.txt
+++ b/readme.txt
@@ -23,15 +23,11 @@ Beautifully display your Gravity Forms entries. Learn more on [gravityview.co](h
 
 = develop =
 
-* Added: Admin Title option for Custom Content fields
 * Added: [gventry edit="1"] mode where edit entry shortcodes can be used now (experimental)
-* Added: `gravityview/shortcodes/gventry/edit/success` filter to modify [gventry] edit success message
-
-= 2.4.2 on October 16, 2019 =
-
 * Added: You can now add labels for Custom Content in the View editor (this helps keep track of many Custom Content fields at once!)
 * Added: "Show as score" setting for Gravity Forms Survey fields
 * Added: Support for [Gravity Forms Pipe Add-On](https://www.gravityforms.com/add-ons/pipe-video-recording/)
+* Modified: Multiple items in exported CSVs are now separated by a semicolon instead of new line. This is more consistent with formatting from other services.
 * Fixed: Number field decimal precision formatting not being respected
 * Fixed: Checkbox output in CSVs will no longer contain HTML by default
 * Fixed: View configuration could be lost when the "Update" button was clicked early in the page load or multiple times rapidly
@@ -55,6 +51,8 @@ Beautifully display your Gravity Forms entries. Learn more on [gravityview.co](h
 
 __Developer Updates:__
 
+* Added: `gravityview/template/field/csv/glue` filter to modify the glue used to separate multiple values in the CSV export (previously "\n", now default is ';')
+* Added: `gravityview/shortcodes/gventry/edit/success` filter to modify [gventry] edit success message
 * Added: `gravityview/search/sieve_choices` filter that sieves Search Widget field filter choices to only ones that have been used in entries (a UI is coming soon)
 * Added: `gravityview/search/filter_details` filter for developers to modify search filter configurations
 * Added: `gravityview/admin/available_fields` filter for developers to add their own assignable fields to View configurations

--- a/templates/fields/field-business_hours-csv.php
+++ b/templates/fields/field-business_hours-csv.php
@@ -22,5 +22,14 @@ if ( $value = json_decode( $value ) ) {
 		$output[] = sprintf( '%s %s - %s', $day->daylabel, $day->fromtime, $day->totimelabel );
 	}
 
-	echo implode( "\n", $output );
+	/**
+	 * @filter `gravityview/template/field/csv/glue` The value used to separate multiple values in the CSV export
+	 * @since 2.4.2
+	 *
+	 * @param[in,out] string The glue. Default: ";" (semicolon)
+	 * @param \GV\Template_Context The context.
+	 */
+	$glue = apply_filters( 'gravityview/template/field/csv/glue', ";", $gravityview );
+
+	echo implode( $glue, $output );
 }

--- a/templates/fields/field-checkbox-csv.php
+++ b/templates/fields/field-checkbox-csv.php
@@ -16,4 +16,13 @@ $display_value = $gravityview->display_value;
 $value = $gravityview->value;
 $entry = $gravityview->entry->as_entry();
 
-echo implode( "\n", array_filter( $value ) );
+/**
+ * @filter `gravityview/template/field/csv/glue` The value used to separate multiple values in the CSV export
+ * @since 2.4.2
+ *
+ * @param[in,out] string The glue. Default: ";" (semicolon)
+ * @param \GV\Template_Context The context.
+ */
+$glue = apply_filters( 'gravityview/template/field/csv/glue', ";", $gravityview );
+
+echo implode( $glue, array_filter( $value ) );

--- a/templates/fields/field-fileupload-csv.php
+++ b/templates/fields/field-fileupload-csv.php
@@ -18,5 +18,15 @@ $entry = $gravityview->entry->as_entry();
 
 if ( ! empty( $value ) ) {
 	$output_arr = gravityview_get_files_array( $value, '', $gravityview );
-	echo implode( "\n", wp_list_pluck( $output_arr, 'file_path' ) );
+
+	/**
+	 * @filter `gravityview/template/field/csv/glue` The value used to separate multiple values in the CSV export
+	 * @since 2.4.2
+	 *
+	 * @param[in,out] string The glue. Default: ";" (semicolon)
+	 * @param \GV\Template_Context The context.
+	 */
+	$glue = apply_filters( 'gravityview/template/field/csv/glue', ";", $gravityview );
+
+	echo implode( $glue, wp_list_pluck( $output_arr, 'file_path' ) );
 }

--- a/templates/fields/field-list-csv.php
+++ b/templates/fields/field-list-csv.php
@@ -32,10 +32,20 @@ if ( $field->enableColumns && false !== $column_id ) {
 	echo GravityView_Field_List::column_value( $field, $value, $column_id, $format );
 
 } else {
+
+	/**
+	 * @filter `gravityview/template/field/csv/glue` The value used to separate multiple values in the CSV export
+	 * @since 2.4.2
+	 *
+	 * @param[in,out] string The glue. Default: ";" (semicolon)
+	 * @param \GV\Template_Context The context.
+	 */
+	$glue = apply_filters( 'gravityview/template/field/csv/glue', ";", $gravityview );
+
 	$value = unserialize( $value );
 	if ( $field->enableColumns ) {
 		$columns = array_keys( current( $value ) );
-		echo implode( ',', $columns ) . "\n";
+		echo implode( ',', $columns ) . $glue;
 	}
 
 	$output = array();
@@ -43,5 +53,5 @@ if ( $field->enableColumns && false !== $column_id ) {
 		$output[] = implode( ',', $column );
 	}
 
-	echo implode( "\n", $output );
+	echo implode( $glue, $output );
 }

--- a/tests/unit-tests/GravityView_Future_Test.php
+++ b/tests/unit-tests/GravityView_Future_Test.php
@@ -7901,23 +7901,62 @@ class GVFuture_Test extends GV_UnitTestCase {
 
 		ob_start();
 		$view::template_redirect();
-		$list = implode( "\n", array(
+
+		$list = implode( ";", array(
 			'Column 1,Column 2',
 			'one,two',
 			'three,four',
 		) );
-		$file = implode( "\n", array(
-			'http://one.txt', 'http://two.mp3'
+
+		$file = implode( ";", array( 'http://one.txt', 'http://two.mp3' ) );
+
+
+		$checkbox = implode( ";", array( 'Much Better', 'Somewhat Better' ) );
+		$expected = array(
+			'Email,"A List",File,Checkbox',
+			sprintf( 'support@gravityview.co,"%s",%s,"%s"', $list, $file, $checkbox ),
+		);
+
+		$this->assertEquals( implode( "\n", $expected ), ob_get_flush() );
+
+
+		$view                                      = \GV\View::from_post( $post );
+		gravityview()->request->returns['is_view'] = $view;
+
+		ob_start();
+
+		add_filter( 'gravityview/template/field/csv/glue', function () {
+			return "\n";
+		} );
+		$view::template_redirect();
+
+		$list_newline     = implode( "\n", array(
+			'Column 1,Column 2',
+			'one,two',
+			'three,four',
 		) );
-		$checkbox = implode( "\n", array( 'Much Better', 'Somewhat Better' ) );
-		$expected = array( 'Email,"A List",File,Checkbox', sprintf( 'support@gravityview.co,"%s","%s","%s"', $list, $file, $checkbox ) );
-		$this->assertEquals( implode( "\n", $expected ), ob_get_clean() );
+		$checkbox_newline = implode( "\n", array( 'Much Better', 'Somewhat Better' ) );
+		$file_newline     = implode( "\n", array(
+			'http://one.txt',
+			'http://two.mp3',
+		) );
+		$expected         = array(
+			'Email,"A List",File,Checkbox',
+			sprintf( 'support@gravityview.co,"%s","%s","%s"', $list_newline, $file_newline, $checkbox_newline ),
+		);
+
+		remove_all_filters( 'gravityview/template/field/csv/glue' );
+
+		$this->assertEquals( implode( "\n", $expected ), ob_get_flush() );
 
 		add_filter( 'gravityview/template/csv/field/raw', '__return_false' );
 
 		ob_start();
 		$view::template_redirect();
-		$expected = array( 'Email,"A List",File,Checkbox', sprintf( '"<a href=\'mailto:support@gravityview.co\'>support@gravityview.co</a>","%s","%s","%s"', $list, $file, $checkbox ) );
+		$expected = array(
+			'Email,"A List",File,Checkbox',
+			sprintf( '"<a href=\'mailto:support@gravityview.co\'>support@gravityview.co</a>","%s",%s,"%s"', $list, $file, $checkbox ),
+		);
 		$this->assertEquals( implode( "\n", $expected ), ob_get_clean() );
 
 		remove_filter( 'gravityview/template/csv/field/raw', '__return_false' );

--- a/tests/unit-tests/GravityView_REST_Test.php
+++ b/tests/unit-tests/GravityView_REST_Test.php
@@ -752,7 +752,6 @@ class GravityView_REST_Test extends GV_RESTUnitTestCase {
 		$this->assertNotContains( '[', $csv );
 		$this->assertContains( 'one.jpg', $csv );
 		$this->assertContains( 'two.mp3', $csv );
-		$this->assertStringEndsWith( '"', $csv );
 	}
 
 	public function test_get_items_raw() {


### PR DESCRIPTION
I looked at HubSpot and Google Forms, and both these tools use semicolons to separate multiple items (like multiple checkboxes).