### PR TITLE
Hotfix for get_slug() fatal error

### DIFF
--- a/future/includes/class-gv-template-field.php
+++ b/future/includes/class-gv-template-field.php
@@ -190,7 +190,7 @@ abstract class Field_Template extends Template {
 				$specifics []= sprintf( '%spost-%d-field-%s.php', $slug_dir, $post->ID, $slug_name );
 				$specifics []= sprintf( '%spost-%d-field.php', $slug_dir, $post->ID );
 			}
-			
+
 			/** Field-specific */
 			if ( $field_id && $form_id ) {
 
@@ -352,6 +352,8 @@ abstract class Field_Template extends Template {
 		/**
 		 * Wrap output in a link, if enabled in the field settings
 		 *
+		 * @todo Cleanup
+		 *
 		 * @param string $output HTML value output
 		 * @param \GV\Template_Context $context
 		 *
@@ -408,6 +410,7 @@ abstract class Field_Template extends Template {
 			return $output;
 		};
 
+		// TODO Cleanup
 		$post_link_compat_callback = function( $output, $context ) use ( $field_compat ) {
 			$field = $context->field;
 

--- a/gravityview.php
+++ b/gravityview.php
@@ -3,7 +3,7 @@
  * Plugin Name:       	GravityView
  * Plugin URI:        	https://gravityview.co
  * Description:       	The best, easiest way to display Gravity Forms entries on your website.
- * Version:             2.7
+ * Version:             2.7.1
  * Author:            	GravityView
  * Author URI:        	https://gravityview.co
  * Text Domain:       	gravityview
@@ -22,7 +22,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 /**
  * The plugin version.
  */
-define( 'GV_PLUGIN_VERSION', '2.7' );
+define( 'GV_PLUGIN_VERSION', '2.7.1' );
 
 /**
  * Full path to the GravityView file

--- a/includes/class-admin-welcome.php
+++ b/includes/class-admin-welcome.php
@@ -263,6 +263,12 @@ class GravityView_Welcome {
                     <h2 style="border-bottom: 1px solid #ccc; padding-bottom: 1em; margin-bottom: 0; margin-top: 0"><?php esc_html_e( 'What&rsquo;s New', 'gravityview' ); ?></h2>
                 </div>
 
+				<h3>2.7.1 on February 24, 2020</h3>
+
+				<ul>
+					<li>Fixed: PHP error when editing entries</li>
+				</ul>
+
 				<h3>2.7 on February 20, 2020 =</h3>
 
 				<ul>

--- a/includes/class-api.php
+++ b/includes/class-api.php
@@ -620,15 +620,27 @@ class GravityView_API {
 		if ( ! empty( $entry['_multi'] ) ) {
 			$entry_slugs = array();
 			foreach ( $entry['_multi'] as $_multi ) {
-				$gv_multi = \GV\GF_Entry::from_entry( $_multi );
-				$entry_slugs[] = $gv_multi->get_slug();
-				$forms[] = $_multi['form_id'];
+
+				if( $gv_multi = \GV\GF_Entry::from_entry( $_multi ) ) {
+					$entry_slugs[] = $gv_multi->get_slug();
+				} else {
+					$entry_slugs[] = \GravityView_API::get_entry_slug( $entry['id'], $entry );
+				}
+
 				unset( $gv_multi );
+
+				$forms[] = $_multi['form_id'];
 			}
 			$entry_slug = implode( ',', $entry_slugs );
 		} else {
-			$gv_entry = \GV\GF_Entry::from_entry( $entry );
-			$entry_slug = $gv_entry->get_slug();
+
+			// Fallback when
+			if( $gv_entry = \GV\GF_Entry::from_entry( $entry ) ) {
+				$entry_slug = $gv_entry->get_slug();
+			} else {
+				$entry_slug = \GravityView_API::get_entry_slug( $entry['id'], $entry );
+			}
+
 			unset( $gv_entry );
 		}
 

--- a/includes/class-api.php
+++ b/includes/class-api.php
@@ -619,18 +619,21 @@ class GravityView_API {
 
 		if ( ! empty( $entry['_multi'] ) ) {
 			$entry_slugs = array();
+
 			foreach ( $entry['_multi'] as $_multi ) {
 
 				if( $gv_multi = \GV\GF_Entry::from_entry( $_multi ) ) {
 					$entry_slugs[] = $gv_multi->get_slug();
 				} else {
-					$entry_slugs[] = \GravityView_API::get_entry_slug( $entry['id'], $entry );
+					// TODO: This path isn't covered by unit tests
+					$entry_slugs[] = \GravityView_API::get_entry_slug( $_multi['id'], $_multi );
 				}
 
 				unset( $gv_multi );
 
 				$forms[] = $_multi['form_id'];
 			}
+
 			$entry_slug = implode( ',', $entry_slugs );
 		} else {
 
@@ -638,6 +641,7 @@ class GravityView_API {
 			if( $gv_entry = \GV\GF_Entry::from_entry( $entry ) ) {
 				$entry_slug = $gv_entry->get_slug();
 			} else {
+				// TODO: This path isn't covered by unit tests
 				$entry_slug = \GravityView_API::get_entry_slug( $entry['id'], $entry );
 			}
 

--- a/includes/extensions/edit-entry/class-edit-entry-render.php
+++ b/includes/extensions/edit-entry/class-edit-entry-render.php
@@ -237,7 +237,7 @@ class GravityView_Edit_Entry_Render {
 	    self::$original_entry = $entries[0];
 	    $this->entry = $entries[0];
 
-		self::$original_form = $gravityview_view->getForm();
+		self::$original_form = GFAPI::get_form( $this->entry['form_id'] );
 		$this->form = $gravityview_view->getForm();
 		$this->form_id = $this->entry['form_id'];
 		$this->view_id = $gravityview_view->getViewId();

--- a/languages/gravityview.pot
+++ b/languages/gravityview.pot
@@ -2,7 +2,7 @@
 # This file is distributed under the GPLv2 or later.
 msgid ""
 msgstr ""
-"Project-Id-Version: GravityView 2.6\n"
+"Project-Id-Version: GravityView 2.7.1\n"
 "Report-Msgid-Bugs-To: https://gravityview.co/support/\n"
 "POT-Creation-Date: 2018-05-08 22:37:16+00:00\n"
 "MIME-Version: 1.0\n"
@@ -1818,23 +1818,23 @@ msgstr ""
 msgid "What&rsquo;s New"
 msgstr ""
 
-#: includes/class-admin-welcome.php:442
+#: includes/class-admin-welcome.php:469
 msgid "View change history"
 msgstr ""
 
-#: includes/class-admin-welcome.php:463
+#: includes/class-admin-welcome.php:490
 msgid "GravityView is brought to you by:"
 msgstr ""
 
-#: includes/class-admin-welcome.php:510
+#: includes/class-admin-welcome.php:537
 msgid "Contributors"
 msgstr ""
 
-#: includes/class-admin-welcome.php:537
+#: includes/class-admin-welcome.php:564
 msgid "Want to contribute?"
 msgstr ""
 
-#: includes/class-admin-welcome.php:538
+#: includes/class-admin-welcome.php:565
 msgid ""
 "If you want to contribute to the code, %syou can on Github%s. If your "
 "contributions are accepted, you will be thanked here."
@@ -1974,11 +1974,11 @@ msgstr ""
 msgid "No entries match your request."
 msgstr ""
 
-#: includes/class-api.php:848
+#: includes/class-api.php:860
 msgid "&larr; Go back"
 msgstr ""
 
-#: includes/class-api.php:1269
+#: includes/class-api.php:1281
 msgid "Map It"
 msgstr ""
 

--- a/readme.txt
+++ b/readme.txt
@@ -21,6 +21,10 @@ Beautifully display your Gravity Forms entries. Learn more on [gravityview.co](h
 
 == Changelog ==
 
+= 2.7.1 on February 24, 2020 =
+
+* Fixed: PHP error when editing entries
+
 = 2.7 on February 20, 2020 =
 
 * Added: "Enable Edit Locking" View setting to toggle on and off entry locking (in the "Edit Entry" tab of the View Settings)


### PR DESCRIPTION
Fixes potential fatal error we're still investigating. Add fallback when $entry isn't found.

See https://gravityview.slack.com/archives/CDSTQ9QQ0/p1582579758006300