### PR TITLE
Add index of the current file in the loop to the gravityview/fields/fileupload/file_path filter

### DIFF
--- a/includes/fields/class-gravityview-field-fileupload.php
+++ b/includes/fields/class-gravityview-field-fileupload.php
@@ -183,9 +183,11 @@ class GravityView_Field_FileUpload extends GravityView_Field {
 			 * @filter `gravityview/fields/fileupload/file_path` Modify the file path before generating a link to it
 			 * @since 1.22.3
 			 * @since 2.0 Added $context parameter
+			 * @since 2.8.2
 			 * @param string $file_path Path to the file uploaded by Gravity Forms
 			 * @param array  $field_settings Array of GravityView field settings
 			 * @param \GV\Template_Context $context The context.
+			 * @param int $index The current index of the $file_paths array being processed
 			 */
 			$file_path = apply_filters( 'gravityview/fields/fileupload/file_path', $file_path, $field_settings, $context, $index );
 

--- a/includes/fields/class-gravityview-field-fileupload.php
+++ b/includes/fields/class-gravityview-field-fileupload.php
@@ -148,7 +148,7 @@ class GravityView_Field_FileUpload extends GravityView_Field {
 		}
 
 		// Process each file path
-		foreach ( $file_paths as $file_path ) {
+		foreach ( $file_paths as $index => $file_path ) {
 
 			$rendered = null;
 
@@ -187,7 +187,7 @@ class GravityView_Field_FileUpload extends GravityView_Field {
 			 * @param array  $field_settings Array of GravityView field settings
 			 * @param \GV\Template_Context $context The context.
 			 */
-			$file_path = apply_filters( 'gravityview/fields/fileupload/file_path', $file_path, $field_settings, $context );
+			$file_path = apply_filters( 'gravityview/fields/fileupload/file_path', $file_path, $field_settings, $context, $index );
 
 			// Audio
 			if ( in_array( $extension, wp_get_audio_extensions() ) ) {


### PR DESCRIPTION
I'm working on a plugin that offloads file uploads in Gravity Forms. The plugin adds meta data about each file, and uses that data later on to overwrite the file path to use the custom location. For multi-file uploads, this meta data is stored in arrays in the order the files were uploaded.

Integrating with Gravity View requires knowing the current file in the [loop of file paths](https://github.com/gravityview/GravityView/blob/master/includes/fields/class-gravityview-field-fileupload.php#L151). Without knowing the current index, it's difficult to know which file is being handled in cases of multi-file uploads. 

This pull request modifies the loop to make the `$index` available to the `gravityview/fields/fileupload/file_path` filter. The `$index` is added as a fourth argument to the filter.