### PR TITLE
GLOB_BRACE defaults to 0. 

### DIFF
--- a/includes/load-plugin-and-theme-hooks.php
+++ b/includes/load-plugin-and-theme-hooks.php
@@ -19,7 +19,7 @@ $include_path = GRAVITYVIEW_DIR . 'includes/plugin-and-theme-hooks/';
 // Abstract class
 require $include_path . 'abstract-gravityview-plugin-and-theme-hooks.php';
 
-$glob_flags = defined( 'GLOB_BRACE' ) ? GLOB_BRACE : 1024;
+$glob_flags = defined( 'GLOB_BRACE' ) ? GLOB_BRACE : 0;
 
 $plugin_theme_hooks_files = glob( $include_path . 'class-gravityview-{plugin,theme}-hooks-*.php', $glob_flags );
 


### PR DESCRIPTION
https://github.com/php/php-src/blob/1c295d4a9ac78fcc2f77d6695987598bb7abcb83/ext/standard/dir.c#L162-L166

With the value `1024` produced php warnings on the WordPress backend once the plugin is enabled.

```
Warning: glob(): At least one of the passed flags is invalid or not supported on this platform in /var/www/html/public/wp-content/plugins/gravityview/includes/load-plugin-and-theme-hooks.php on line 24 
Warning: include(): Filename cannot be empty in /var/www/html/public/wp-content/plugins/gravityview/includes/load-plugin-and-theme-hooks.php on line 28 
Warning: include(): Failed opening '' for inclusion (include_path='.:/usr/local/lib/php') in /var/www/html/public/wp-content/plugins/gravityview/includes/load-plugin-and-theme-hooks.php on line 28 
Warning: Cannot modify header information - headers already sent by (output started at /var/www/html/public/wp-content/plugins/gravityview/includes/load-plugin-and-theme-hooks.php:24) in /var/www/html/public/wp/wp-includes/functions.php on line 6270 
Warning: Cannot modify header information - headers already sent by (output started at /var/www/html/public/wp-content/plugins/gravityview/includes/load-plugin-and-theme-hooks.php:24) in /var/www/html/public/wp/wp-admin/includes/misc.php on line 1310 
Warning: Cannot modify header information - headers already sent by (output started at /var/www/html/public/wp-content/plugins/gravityview/includes/load-plugin-and-theme-hooks.php:24) in /var/www/html/public/wp/wp-admin/admin-header.php on line 9
```
