### PR TITLE
Fix search widget returning incorrect results when using "is" operator

### DIFF
--- a/includes/widgets/search-widget/class-search-widget.php
+++ b/includes/widgets/search-widget/class-search-widget.php
@@ -753,6 +753,15 @@ class GravityView_Widget_Search extends \GV\Widget {
 
 			$filter_key = $this->convert_request_key_to_filter_key( $key );
 
+			if ( '' === $value ) {
+				$field = GFAPI::get_field( $view->form->ID, $filter_key );
+
+				// GF_Query casts Number field values to decimal, which may return unexpected result when the value is blank.
+				if ( $field && 'number' === $field->type ) {
+					$value = '-' . PHP_INT_MAX;
+				}
+			}
+
 			if ( ! $filter = $this->prepare_field_filter( $filter_key, $value, $view, $searchable_field_objects, $get ) ) {
 				continue;
 			}

--- a/includes/widgets/search-widget/class-search-widget.php
+++ b/includes/widgets/search-widget/class-search-widget.php
@@ -740,7 +740,11 @@ class GravityView_Widget_Search extends \GV\Widget {
 			}
 
 			if ( gv_empty( $value, false, false ) || ( is_array( $value ) && count( $value ) === 1 && gv_empty( $value[0], false, false ) ) ) {
-				continue;
+				if ( is_array( $value ) ) {
+					continue;
+				}
+
+				$value = '';
 			}
 
 			if ( strpos( $key, '|op' ) !== false ) {
@@ -831,7 +835,7 @@ class GravityView_Widget_Search extends \GV\Widget {
 		$extra_conditions = array();
 		$mode = 'any';
 
-		foreach ( $search_criteria['field_filters'] as &$filter ) {
+		foreach ( $search_criteria['field_filters'] as $key => &$filter ) {
 			if ( ! is_array( $filter ) ) {
 				if ( in_array( strtolower( $filter ), array( 'any', 'all' ) ) ) {
 					$mode = $filter;
@@ -892,6 +896,10 @@ class GravityView_Widget_Search extends \GV\Widget {
 			 * @param \GV\View $view The View we're operating on.
 			 */
 			$filter['operator'] = apply_filters( 'gravityview_search_operator', $filter['operator'], $filter, $view );
+
+			if ( 'is' !== $filter['operator'] && '' === $filter['value'] ) {
+				unset( $search_criteria['field_filters'][ $key ] );
+			}
 		}
 
 		if ( ! empty( $search_criteria['start_date'] ) || ! empty( $search_criteria['end_date'] ) ) {

--- a/includes/widgets/search-widget/class-search-widget.php
+++ b/includes/widgets/search-widget/class-search-widget.php
@@ -940,6 +940,25 @@ class GravityView_Widget_Search extends \GV\Widget {
 					$search_conditions[] = $search_condition;
 				} else {
 					$left = $search_condition->left;
+
+					// When casting a column value to a certain type (e.g., happens with the Number field), GF_Query_Column is wrapped in a GF_Query_Call class.
+					if ( $left instanceof GF_Query_Call ) {
+						try {
+							$reflectionProperty = new \ReflectionProperty( $left, '_parameters' );
+							$reflectionProperty->setAccessible( true );
+
+							$value = $reflectionProperty->getValue( $left );
+
+							if ( ! empty( $value[0] ) && $value[0] instanceof GF_Query_Column ) {
+								$left = $value[0];
+							} else {
+								continue;
+							}
+						} catch ( ReflectionException $e ) {
+							continue;
+						}
+					}
+
 					$alias = $query->_alias( $left->field_id, $left->source, $left->is_entry_column() ? 't' : 'm' );
 
 					if ( $view->joins && $left->field_id == GF_Query_Column::META ) {

--- a/readme.txt
+++ b/readme.txt
@@ -23,6 +23,8 @@ Beautifully display your Gravity Forms entries. Learn more on [gravityview.co](h
 
 = develop =
 
+* Fixed: Search widget would cause a fatal error when the Number field is used with the "is" operator
+* Fixed: Search widget returning incorrect results when a field value is blank and the operator is set to "is"
 * Fixed: Gravity Forms widget icon not showing
 * Fixed: Gravity Forms widget not displaying available forms when the View is saved
 

--- a/tests/unit-tests/GravityView_Widget_Search_Test.php
+++ b/tests/unit-tests/GravityView_Widget_Search_Test.php
@@ -687,6 +687,7 @@ class GravityView_Widget_Search_Test extends GV_UnitTestCase {
 				),
 			),
 		) );
+
 		$view = \GV\View::from_post( $post );
 
 		$did_unapproved_meta = false;
@@ -721,6 +722,7 @@ class GravityView_Widget_Search_Test extends GV_UnitTestCase {
 
 		$_GET = array();
 	}
+
 
 	public function get_test_approval_status_search() {
 		return array(
@@ -1488,6 +1490,86 @@ class GravityView_Widget_Search_Test extends GV_UnitTestCase {
 		$this->assertEquals( 1, $view->get_entries()->count() );
 		remove_filter( 'gravityview/search-trim-input', '__return_false' );
 		remove_filter( 'gravityview/search-all-split-words', '__return_false' );
+
+		$_GET = array();
+	}
+
+	public function test_search_with_empty_values() {
+		if ( ! gravityview()->plugin->supports( \GV\Plugin::FEATURE_GFQUERY ) ) {
+			$this->markTestSkipped( 'Requires \GF_Query from Gravity Forms 2.3' );
+		}
+
+		$form = $this->factory->form->import_and_get( 'complete.json' );
+		$post = $this->factory->view->create_and_get( array(
+			'form_id'     => $form['id'],
+			'template_id' => 'table',
+			'fields'      => array(
+				'directory_table-columns' => array(
+					wp_generate_password( 4, false )  => array(
+						'id'    => '8.3',
+						'label' => 'First',
+					),
+					wp_generate_password( 16, false ) => array(
+						'id'    => '8.6',
+						'label' => 'Last',
+					),
+				),
+			),
+			'settings'    => array(
+				'show_only_approved' => false,
+			),
+			'widgets'     => array(
+				'header_top' => array(
+					wp_generate_password( 4, false ) => array(
+						'id'            => 'search_bar',
+						'search_fields' => json_encode( array(
+								array(
+									'field' => '8.3',
+								),
+								array(
+									'field' => '8.6',
+								)
+							)
+						),
+					),
+				)
+			),
+		) );
+
+		$view = \GV\View::from_post( $post );
+
+		$data = array(
+			array( 'Alice', 'Alice' ),
+			array( 'Alice', 'Bob' ),
+			array( 'Alice', 'Alice' ),
+		);
+
+		foreach ( $data as $name ) {
+			$this->factory->entry->create_and_get( array(
+				'form_id' => $form['id'],
+				'status'  => 'active',
+				'8.3'     => $name[0],
+				'8.6'     => $name[1],
+			) );
+		}
+
+		// Default "contains" operator
+		$_GET = array( 'filter_8_3' => 'Alice', 'filter_8_6' => '', 'mode' => 'all' );
+
+		$this->assertEquals( 3, $view->get_entries()->count() );
+
+		// "is" operator
+		add_filter( 'gravityview_search_operator', function () {
+			return 'is';
+		} );
+
+		$this->assertEquals( 0, $view->get_entries()->count() );
+
+		$_GET = array( 'filter_8_3' => 'Alice', 'filter_8_6' => 'Alice', 'mode' => 'all' );
+
+		$this->assertEquals( 2, $view->get_entries()->count() );
+
+		remove_all_filters('gravityview_search_operator');
 
 		$_GET = array();
 	}

--- a/tests/unit-tests/GravityView_Widget_Search_Test.php
+++ b/tests/unit-tests/GravityView_Widget_Search_Test.php
@@ -1628,6 +1628,10 @@ class GravityView_Widget_Search_Test extends GV_UnitTestCase {
 
 		$this->assertEquals( 1, $view->get_entries()->count() );
 
+		$_GET = array( 'filter_9' => '', 'mode' => 'all' );
+
+		$this->assertEquals( 0, $view->get_entries()->count() );
+
 		remove_all_filters('gravityview_search_operator');
 
 		$_GET = array();


### PR DESCRIPTION
Removing search filters with empty values would produce incorrect results when the operator is set to "is". 